### PR TITLE
v0.2.2: add "volume" as a measure for xyz profiles

### DIFF
--- a/notebooks/example.api.high.ipynb
+++ b/notebooks/example.api.high.ipynb
@@ -75,7 +75,7 @@
      "text": [
       "[pywarper] Fitting SAC surfaces …\n",
       "↳ fitting OFF (max) surface\n",
-      "    done in 0.08 seconds.\n",
+      "    done in 0.07 seconds.\n",
       "↳ fitting ON (min) surface\n",
       "    done in 0.06 seconds.\n"
      ]
@@ -83,7 +83,7 @@
     {
      "data": {
       "text/plain": [
-       "<pywarper.warpers.Warper at 0x107947890>"
+       "<pywarper.warpers.Warper at 0x11fe1b390>"
       ]
      },
      "execution_count": 4,
@@ -115,15 +115,15 @@
      "text": [
       "[pywarper] Building mapping …\n",
       "↳ mapping ON (min) surface …\n",
-      "    done in 0.27 seconds.\n",
+      "    done in 0.29 seconds.\n",
       "↳ mapping OFF (max) surface …\n",
-      "    done in 0.28 seconds.\n"
+      "    done in 0.30 seconds.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<pywarper.warpers.Warper at 0x107947890>"
+       "<pywarper.warpers.Warper at 0x11fe1b390>"
       ]
      },
      "execution_count": 5,
@@ -152,13 +152,14 @@
      "output_type": "stream",
      "text": [
       "[pywarper] Warping skeleton...\n",
-      "    done in 1.45 seconds.\n"
+      "    done in 1.45 seconds.\n",
+      "[skeliner] Warning: 58 nodes have zero radius; they were ignored when picking the estimator.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<pywarper.warpers.Warper at 0x107947890>"
+       "<pywarper.warpers.Warper at 0x11fe1b390>"
       ]
      },
      "execution_count": 6,
@@ -267,7 +268,7 @@
     "# --------------------------------------------------------------------------- #\n",
     "# 4.  Right panel — fixed-width stratification profile\n",
     "# --------------------------------------------------------------------------- #\n",
-    "zp = w.warped_skeleton.extra[\"z_profile\"]\n",
+    "zp = w.warped_skeleton.extra[\"z_profiles\"][\"length\"]\n",
     "ax_prof.plot(zp[\"distribution\"], zp[\"x\"], lw=2, c='black')\n",
     "ax_prof.barh(zp[\"x\"], zp[\"histogram\"], color='gray', alpha=0.5)\n",
     "ax_prof.set_xlabel('dendritic length')\n",
@@ -281,7 +282,7 @@
     "for ax in (ax_nodes, ax_prof):\n",
     "    ax.set_ylim([-30, 30])\n",
     "\n",
-    "z_hdr = w.warped_skeleton.extra[\"z_profile\"][\"hdr\"]\n",
+    "z_hdr = w.warped_skeleton.extra[\"z_profiles\"][\"length\"][\"hdr\"]\n",
     "\n",
     "for i, (z_lo, z_hi) in enumerate(z_hdr):\n",
     "    # left panel (xz view)\n",
@@ -310,8 +311,9 @@
     "hull = get_convex_hull(w.warped_skeleton.nodes[:, 0:2])\n",
     "com_hull = get_hull_centroid(hull)\n",
     "\n",
-    "xy_profile: dict = w.warped_skeleton.extra[\"xy_profile\"]\n",
+    "xy_profile: dict = w.warped_skeleton.extra[\"xy_profiles\"][\"length\"]\n",
     "xy_dist = xy_profile[\"distribution\"]\n",
+    "xy_extents = xy_profile[\"extents\"]\n",
     "xy_x = xy_profile[\"x\"]\n",
     "xy_y = xy_profile[\"y\"]\n",
     "com_xy = get_xy_center_of_mass(xy_x, xy_y, xy_dist)"
@@ -333,7 +335,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x117d08f50>"
+       "<matplotlib.legend.Legend at 0x121796d10>"
       ]
      },
      "execution_count": 9,
@@ -352,10 +354,6 @@
     }
    ],
    "source": [
-    "xy_profile: dict = w.warped_skeleton.extra[\"xy_profile\"]\n",
-    "xy_dist = xy_profile[\"distribution\"]\n",
-    "xy_extents = xy_profile[\"extents\"]\n",
-    "\n",
     "fig, ax = plt.subplots(figsize=(6, 6))\n",
     "\n",
     "sk.plot2d(\n",
@@ -400,30 +398,6 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "fcbdda71",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[np.float64(80.0),\n",
-       " np.float64(240.00000000000006),\n",
-       " np.float64(60.0),\n",
-       " np.float64(240.00000000000006)]"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "w.warped_skeleton.extra[\"xy_profile\"][\"extents\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
    "id": "48ec81d6",
    "metadata": {},
    "outputs": [
@@ -431,16 +405,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Last updated: 2025-06-19 09:37:12CEST\n",
+      "Last updated: 2025-09-10 12:23:51CEST\n",
       "\n",
       "Python implementation: CPython\n",
       "Python version       : 3.11.11\n",
       "IPython version      : 9.3.0\n",
       "\n",
       "matplotlib: 3.10.3\n",
-      "pywarper  : 0.2.1\n",
       "numpy     : 2.2.6\n",
-      "skeliner  : 0.1.6\n",
+      "skeliner  : 0.1.14\n",
+      "pywarper  : 0.2.2\n",
       "\n",
       "Watermark: 2.5.0\n",
       "\n"

--- a/notebooks/example.api.high.ipynb
+++ b/notebooks/example.api.high.ipynb
@@ -455,7 +455,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": ".venv (3.11.11)",
    "language": "python",
    "name": "python3"
   },

--- a/notebooks/example.api.low.ipynb
+++ b/notebooks/example.api.low.ipynb
@@ -91,7 +91,8 @@
      "output_type": "stream",
      "text": [
       "[pywarper] Warping skeleton...\n",
-      "    done in 1.25 seconds.\n"
+      "    done in 1.42 seconds.\n",
+      "[skeliner] Warning: 58 nodes have zero radius; they were ignored when picking the estimator.\n"
      ]
     }
    ],
@@ -194,10 +195,13 @@
     "ax_nodes.spines['top'].set_visible(False)\n",
     "ax_nodes.spines['right'].set_visible(False)\n",
     "ax_nodes.set_title(\"Warped skeleton\")\n",
+    "\n",
     "# --------------------------------------------------------------------------- #\n",
     "# 4.  Right panel — fixed-width stratification profile\n",
     "# --------------------------------------------------------------------------- #\n",
-    "zp = warped_skeleton.extra[\"z_profile\"]\n",
+    "zp = warped_skeleton.extra[\"z_profiles\"][\"length\"] # or volume\n",
+    "    # here we show the z profile computed from the path length\n",
+    "    # alternatively, you can use the one computed from neurite \"volume\"\n",
     "ax_prof.plot(zp[\"distribution\"], zp[\"x\"], lw=2, c='black')\n",
     "ax_prof.barh(zp[\"x\"], zp[\"histogram\"], color='gray', alpha=0.5)\n",
     "ax_prof.set_xlabel('dendritic length')\n",
@@ -211,7 +215,7 @@
     "for ax in (ax_nodes, ax_prof):\n",
     "    ax.set_ylim([-30, 30])\n",
     "\n",
-    "z_hdr = warped_skeleton.extra[\"z_profile\"][\"hdr\"]\n",
+    "z_hdr = warped_skeleton.extra[\"z_profiles\"][\"length\"][\"hdr\"]\n",
     "\n",
     "for i, (z_lo, z_hi) in enumerate(z_hdr):\n",
     "    # left panel (xz view)\n",
@@ -231,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "45f5a1d0",
    "metadata": {},
    "outputs": [],
@@ -239,8 +243,9 @@
     "hull = get_convex_hull(warped_skeleton.nodes[:, 0:2])\n",
     "com_hull = get_hull_centroid(hull)\n",
     "\n",
-    "xy_profile = warped_skeleton.extra[\"xy_profile\"]\n",
+    "xy_profile = warped_skeleton.extra[\"xy_profiles\"][\"length\"]\n",
     "xy_dist = xy_profile[\"distribution\"]\n",
+    "xy_extent = xy_profile[\"extents\"]\n",
     "xy_x = xy_profile[\"x\"]\n",
     "xy_y = xy_profile[\"y\"]\n",
     "com_xy = get_xy_center_of_mass(xy_x, xy_y, xy_dist)"
@@ -248,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "13697fb5",
    "metadata": {},
    "outputs": [
@@ -262,7 +267,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x12139fb50>"
+       "<matplotlib.legend.Legend at 0x115783bd0>"
       ]
      },
      "execution_count": 8,
@@ -281,11 +286,6 @@
     }
    ],
    "source": [
-    "\n",
-    "xy_profile = warped_skeleton.extra[\"xy_profile\"]\n",
-    "xy_dist = xy_profile[\"distribution\"]\n",
-    "xy_extent = xy_profile[\"extents\"]\n",
-    "\n",
     "fig, ax = plt.subplots(figsize=(6, 6))\n",
     "\n",
     "sk.plot2d(\n",
@@ -337,16 +337,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Last updated: 2025-06-19 09:37:25CEST\n",
+      "Last updated: 2025-09-10 12:22:21CEST\n",
       "\n",
       "Python implementation: CPython\n",
       "Python version       : 3.11.11\n",
       "IPython version      : 9.3.0\n",
       "\n",
-      "skeliner  : 0.1.6\n",
-      "pywarper  : 0.2.1\n",
       "matplotlib: 3.10.3\n",
       "numpy     : 2.2.6\n",
+      "skeliner  : 0.1.14\n",
+      "pywarper  : 0.2.2\n",
       "\n",
       "Watermark: 2.5.0\n",
       "\n"

--- a/notebooks/example.api.low.ipynb
+++ b/notebooks/example.api.low.ipynb
@@ -361,7 +361,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": ".venv (3.11.11)",
    "language": "python",
    "name": "python3"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pywarper"
-version = "0.2.1"
+version = "0.2.2"
 description = "Conformal mapping-based warping of neuronal morphologies."
 authors = []
 requires-python = ">=3.10.0"
@@ -13,7 +13,7 @@ dependencies = [
     "numpy>=2.2.0",
     "pygridfit>=0.1.5",
     "scipy>=1.15.0",
-    "skeliner>=0.1.6",
+    "skeliner>=0.1.14",
     "watermark>=2.5.0",
 ]
 license = "GPL-3.0-or-later"

--- a/pywarper/warpers.py
+++ b/pywarper/warpers.py
@@ -571,22 +571,41 @@ def segment_lengths(skel: Skeleton) -> tuple[np.ndarray, np.ndarray]:
     return lengths, mid
 
 
-def _z_profile_volume_union(
+def segment_volumes(
     skel: Skeleton,
-    extent: list[float | int] | None,
-    bin_size: float,
     *,
-    voxel_size: float | None,
-    include_soma: bool,
-    hdr_mass: float,
-) -> dict:
-    """Union-correct z-profile of **volume** via dx._voxelize_union (no double-counting)."""
-    # tight bbox from cable radii; expand with soma AABB only if requested
-    # (mirrors dx.volume/area defaults)
-    # pick a radii metric automatically (only used for bbox & frusta voxelization)
-    radius_metric = skel.recommend_radius()[0]
+    voxel_size: float | None = None,
+    include_soma: bool = False,
+    radius_metric: str | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Union‑correct *per‑z slice* volumes as weights + sample positions.
+
+    This mirrors `segment_lengths()` in return shape, but the notion of a
+    “segment” here is a **z‑slice of the union** (frusta + optional soma),
+    not an edge.
+
+    Returns
+    -------
+    volumes : (K,) float
+        Union volume per *non‑empty* z‑slice (in unit³).
+    mid     : (K, 3) float
+        Sample positions for each slice: (x̄, ȳ, z_center), where x̄,ȳ are
+        slice area‑weighted centroids and z_center is the slice center.
+
+    Notes
+    -----
+    * Uses `dx._voxelize_union` once; no double counting at branch junctions
+      or soma contacts.
+    * If you don't care about x̄,ȳ, you can replace them with zeros to save
+      a tiny bit of compute; z‑profiles only use `mid[:,2]`.
+    """
+    # choose radii column for voxelizer / bbox
+    if radius_metric is None:
+        radius_metric = skel.recommend_radius()[0]
     radii = np.asarray(skel.radii[radius_metric], dtype=np.float64).reshape(-1)
 
+    # tight auto‑bbox (like dx.volume/area)
     lo_nodes = (skel.nodes - radii[:, None]).min(axis=0)
     hi_nodes = (skel.nodes + radii[:, None]).max(axis=0)
     if include_soma and getattr(skel, "soma", None) is not None:
@@ -596,75 +615,41 @@ def _z_profile_volume_union(
     else:
         lo, hi = lo_nodes, hi_nodes
 
-    # single union voxelization
+    # one voxelization of the union
     occ, h, (nx, ny, nz), lo, hi = _voxelize_union(
         skel, radii, lo, hi, voxel_size=voxel_size, include_soma=include_soma
     )
-    unit = skel.meta.get("unit", "µm")
-
     if nz == 0:
-        return {
-            "x": np.array([]),
-            "distribution": np.array([]),
-            "histogram": np.array([]),
-            "extent": [0, 0],
-            "n_bins": 0,
-            "bin_size": bin_size,
-            "hdr": [],
-            "hdr_mass": hdr_mass,
-            "measure": "volume",
-            "y_units": f"{unit}³",
-            "voxel_size": h,
-            "grid_shape": (nx, ny, nz),
-            "include_soma": include_soma,
-        }
+        return np.zeros(0, dtype=float), np.zeros((0, 3), dtype=float)
 
-    z_centres = lo[2] + (np.arange(nz) + 0.5) * h  # slice centers
-    # per-slice volume (occupied voxels × voxel volume)
-    w = occ.sum(axis=(0, 1)).astype(np.float64) * (h**3)  # (nz,)
+    # volume per slice (occupied count × voxel volume)
+    vol_all = occ.sum(axis=(0, 1)).astype(np.float64) * (h**3)  # (nz,)
 
-    # window
-    if extent is None:
-        z_min, z_max = float(z_centres.min()), float(z_centres.max())
-    else:
-        z_min, z_max = extent
+    # keep only non‑empty slices
+    mask = vol_all > 0.0
+    if not mask.any():
+        return np.zeros(0, dtype=float), np.zeros((0, 3), dtype=float)
+    vol = vol_all[mask]
+    k = np.where(mask)[0]  # slice indices kept
 
-    # histogram bins
-    n_bins = int(np.ceil((z_max - z_min) / bin_size))
-    edges = z_min + np.arange(n_bins + 1) * bin_size
-    edges[-1] = z_max
+    # z center for each kept slice
+    zc = lo[2] + (k + 0.5) * h
 
-    z_hist, _ = np.histogram(z_centres, bins=edges, weights=w)
-    tot = w.sum()
-    if z_hist.sum() > 0:
-        z_hist *= tot / z_hist.sum()
+    # area‑weighted centroids per kept slice (optional but nice to have)
+    xs = lo[0] + (np.arange(nx) + 0.5) * h  # (nx,)
+    ys = lo[1] + (np.arange(ny) + 0.5) * h  # (ny,)
+    occ_sel = occ[:, :, mask]  # (nx, ny, K)
 
-    # KB-smoothed density (mass-preserving)
-    centre = (z_min + z_max) / 2.0
-    halfspan = (z_max - z_min) / 2.0
-    z_samples = (z_centres - centre) / max(halfspan, np.finfo(float).eps)
-    z_dist = gridder1d(z_samples / 2.0, w, n_bins)
-    if z_dist.sum() > 0:
-        z_dist *= tot / z_dist.sum()
+    counts = occ_sel.sum(axis=(0, 1)).astype(np.float64)  # (K,)
+    sum_x = (occ_sel * xs[:, None, None]).sum(axis=(0, 1))  # (K,)
+    sum_y = (occ_sel * ys[None, :, None]).sum(axis=(0, 1))  # (K,)
 
-    x_um = 0.5 * (edges[1:] + edges[:-1])
-    intervals = hdr(x_um, z_dist, mass=hdr_mass)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        xbar = np.where(counts > 0, sum_x / counts, (lo[0] + hi[0]) / 2.0)
+        ybar = np.where(counts > 0, sum_y / counts, (lo[1] + hi[1]) / 2.0)
 
-    return {
-        "x": x_um,
-        "distribution": z_dist,
-        "histogram": z_hist,
-        "extent": [z_min, z_max],
-        "n_bins": n_bins,
-        "bin_size": bin_size,
-        "hdr": intervals,
-        "hdr_mass": hdr_mass,
-        "measure": "volume",
-        "y_units": f"{unit}³",
-        "voxel_size": h,
-        "grid_shape": (nx, ny, nz),
-        "include_soma": include_soma,
-    }
+    mid = np.column_stack((xbar, ybar, zc)).astype(np.float64)
+    return vol, mid
 
 
 def gridder1d(
@@ -756,8 +741,9 @@ def get_z_profile(
     bin_size: float = 1,  # µm
     hdr_mass: float = 0.95,
     *,
-    measure: str = "length",  # ["length", "area", "volume"]
-    voxel_size: float | None = None,  # only used for area/volume (union)
+    measure: str = "length",  # ["length", "volume"]
+    radius_metric: str | None = None,
+    voxel_size: float | None = None,  # only used for volume (union)
     include_soma: bool = False,
 ) -> dict:
     """
@@ -765,73 +751,73 @@ def get_z_profile(
 
     measure:
         "length" – cable length per bin (histogram + KB‑smoothed).
-        "area"   – **union‑correct** membrane surface area per bin (voxel union).
         "volume" – **union‑correct** morphology volume per bin (voxel union).
 
     Notes
     -----
-    * Area/volume use a single voxelization (dx._voxelize_union) and
+    * volume uses a single voxelization (dx._voxelize_union) and
       **do not double count** at branch junctions or soma contacts.
     * 'include_soma' defaults to False to match the 'length' convention
       (edges only). Set True if you want soma membrane/volume included.
     * For stable plots, keep bin_size ≥ voxel_size (if you set voxel_size).
     """
+
     if measure == "length":
         density, nodes = segment_lengths(skel)
-        z_vals = nodes[:, 2]
-
-        # window
-        if extent is None:
-            z_min, z_max = np.floor(z_vals.min()), np.ceil(z_vals.max())
-        else:
-            z_min, z_max = extent
-
-        # histogram bins
-        n_bins = int(np.ceil((z_max - z_min) / bin_size))
-        edges = z_min + np.arange(n_bins + 1) * bin_size
-        edges[-1] = z_max
-
-        # histogram (mass-preserving)
-        z_hist, _ = np.histogram(z_vals, bins=edges, weights=density)
-        if z_hist.sum() > 0:
-            z_hist *= density.sum() / z_hist.sum()
-
-        # Kaiser–Bessel gridding (centre to [-1,1], then /2 → [-0.5,0.5])
-        centre = (z_min + z_max) / 2.0
-        halfspan = (z_max - z_min) / 2.0
-        z_samples = (z_vals - centre) / max(halfspan, np.finfo(float).eps)
-        z_dist = gridder1d(z_samples / 2.0, density, n_bins)
-        if z_dist.sum() > 0:
-            z_dist *= density.sum() / z_dist.sum()
-
-        x_um = 0.5 * (edges[1:] + edges[:-1])
-        intervals = hdr(x_um, z_dist, mass=hdr_mass)
-        unit = skel.meta.get("unit", "µm")
-
-        return {
-            "x": x_um,
-            "distribution": z_dist,
-            "histogram": z_hist,
-            "extent": [z_min, z_max],
-            "n_bins": n_bins,
-            "bin_size": bin_size,
-            "hdr": intervals,
-            "hdr_mass": hdr_mass,
-            "measure": "length",
-            "y_units": unit,
-        }
-
-    if measure == "volume":
-        return _z_profile_volume_union(
+    elif measure == "volume":
+        density, nodes = segment_volumes(
             skel,
-            extent,
-            bin_size,
             voxel_size=voxel_size,
             include_soma=include_soma,
-            hdr_mass=hdr_mass,
+            radius_metric=radius_metric,
         )
+    else:
+        raise ValueError("measure must be one of {'length','volume'}")
 
-    raise ValueError("measure must be one of {'length','volume'}")
+    z_vals = nodes[:, 2]
+
+    # window
+    if extent is None:
+        z_min, z_max = np.floor(z_vals.min()), np.ceil(z_vals.max())
+    else:
+        z_min, z_max = extent
+
+    # histogram bins
+    n_bins = max(1, int(np.ceil((z_max - z_min) / bin_size)))
+    edges = z_min + np.arange(n_bins + 1) * bin_size
+    edges[-1] = z_max
+
+    # histogram (mass‑preserving)
+    z_hist, _ = np.histogram(z_vals, bins=edges, weights=density)
+    tot = density.sum()
+    if z_hist.sum() > 0:
+        z_hist *= tot / z_hist.sum()
+
+    # Kaiser–Bessel smoothing (same as length)
+    centre = (z_min + z_max) / 2.0
+    halfspan = (z_max - z_min) / 2.0
+    z_samples = (z_vals - centre) / max(halfspan, np.finfo(float).eps)
+    z_dist = gridder1d(z_samples / 2.0, density, n_bins)
+    if z_dist.sum() > 0:
+        z_dist *= tot / z_dist.sum()
+
+    x_um = 0.5 * (edges[1:] + edges[:-1])
+    intervals = hdr(x_um, z_dist, mass=hdr_mass)
+    unit = skel.meta.get("unit", "µm")
+
+    return {
+        "x": x_um,
+        "distribution": z_dist,
+        "histogram": z_hist,
+        "extent": [z_min, z_max],
+        "n_bins": n_bins,
+        "bin_size": bin_size,
+        "hdr": intervals,
+        "hdr_mass": hdr_mass,
+        "measure": measure,
+        "y_units": unit if measure == "length" else f"{unit}³",
+        "include_soma": include_soma,
+    }
 
 
 def _edges_from_bin_size(lo: float, hi: float, bin_size: float) -> np.ndarray:

--- a/pywarper/warpers.py
+++ b/pywarper/warpers.py
@@ -336,11 +336,14 @@ def warp_skeleton(
     z_profile_extent: list[float | int] | None = None,  # [z_min, z_max]
     z_profile_bin_size: float | int = 1.0,
     z_profile_hdr_mass: float | int = 0.95,
-    z_profile_measure: str = "length",  # ["length","area","volume"]
     z_profile_include_soma: bool = False,
+    z_profile_voxel_size: float | None = None,
     xy_profile_extents: list[float | int] | None = None,  # [x_min, x_max, y_min, y_max]
     xy_profile_bin_size: float | int = 20.0,
     xy_profile_smooth: float = 1.0,
+    xy_profile_include_soma: bool = False,
+    xy_profile_voxel_size: float | None = None,
+    radius_metric: str | None = None,
     skeleton_nodes_scale: float = 1.0,
     conformal_jump: int | None = None,
     backward_compatible: bool = False,
@@ -443,28 +446,40 @@ def warp_skeleton(
         meta=skel.meta.copy(),
     )
 
-    z_profile = get_z_profile(
-        skel_norm,
-        extent=z_profile_extent,
-        bin_size=z_profile_bin_size,
-        hdr_mass=z_profile_hdr_mass,
-        measure=z_profile_measure,
-        include_soma=z_profile_include_soma,
-    )
-    xy_profile = get_xy_profile(
-        skel_norm,
-        extents=xy_profile_extents,
-        bin_size=xy_profile_bin_size,
-        smooth=xy_profile_smooth,
-    )
+    z_profiles = {
+        measure: get_z_profile(
+            skel_norm,
+            extent=z_profile_extent,
+            bin_size=z_profile_bin_size,
+            hdr_mass=z_profile_hdr_mass,
+            measure=measure,
+            include_soma=z_profile_include_soma,
+            voxel_size=z_profile_voxel_size,
+            radius_metric=radius_metric,
+        )
+        for measure in ["length", "volume"]
+    }
+    xy_profiles = {
+        measure: get_xy_profile(
+            skel_norm,
+            extents=xy_profile_extents,
+            bin_size=xy_profile_bin_size,
+            smooth=xy_profile_smooth,
+            measure="length",
+            include_soma=xy_profile_include_soma,
+            voxel_size=xy_profile_voxel_size,
+            radius_metric=radius_metric,
+        )
+        for measure in ["length", "volume"]
+    }
 
     skel_norm.extra = {
         "prenormed_nodes": warped_nodes
         * voxel_resolution,  # keep the pre-normed warped nodes for future use
         "med_z_on": float(med_z_on),
         "med_z_off": float(med_z_off),
-        "z_profile": z_profile,
-        "xy_profile": xy_profile,
+        "z_profiles": z_profiles,
+        "xy_profiles": xy_profiles,
     }
     skel_norm.meta.update(
         {
@@ -868,6 +883,8 @@ def get_z_profile(
         "measure": measure,
         "y_units": unit if measure == "length" else f"{unit}³",
         "include_soma": include_soma,
+        "voxel_size": voxel_size,
+        "radius_metric": radius_metric,
     }
 
 
@@ -971,6 +988,8 @@ def get_xy_profile(
         "measure": measure,
         "units": units,
         "include_soma": include_soma,
+        "voxel_size": voxel_size,
+        "radius_metric": radius_metric,
     }
 
 
@@ -1204,14 +1223,19 @@ class Warper:
 
     def warp_skeleton(
         self,
+        on_sac_pos: float = 0.0,
+        off_sac_pos: float = 12.0,
         z_profile_extent: list[float | int] | None = None,
         z_profile_bin_size: float | int = 1,  # um
         z_profile_hdr_mass: float | int = 0.95,
-        z_profile_measure: str = "length",  # ["length","area","volume"]
         z_profile_include_soma: bool = False,
+        z_profile_voxel_size: float | None = None,
         xy_profile_extents: list[float | int] | None = None,
         xy_profile_bin_size: float | int = 20,  # um
         xy_profile_smooth: float | int = 1.0,
+        xy_profile_include_soma: bool = False,
+        xy_profile_voxel_size: float | None = None,
+        radius_metric: str | None = None,
         skeleton_nodes_scale: float = 1.0,
         voxel_resolution: list[float | int] | None = None,
         conformal_jump: int | None = None,
@@ -1227,16 +1251,21 @@ class Warper:
         self.warped_skeleton = warp_skeleton(
             self.skeleton,
             self.mapping,
+            on_sac_pos=on_sac_pos,
+            off_sac_pos=off_sac_pos,
             voxel_resolution=voxel_resolution,
             conformal_jump=conformal_jump,
             z_profile_extent=z_profile_extent,
             z_profile_bin_size=z_profile_bin_size,
             z_profile_hdr_mass=z_profile_hdr_mass,
-            z_profile_measure=z_profile_measure,
             z_profile_include_soma=z_profile_include_soma,
+            z_profile_voxel_size=z_profile_voxel_size,
             xy_profile_extents=xy_profile_extents,
             xy_profile_bin_size=xy_profile_bin_size,
             xy_profile_smooth=xy_profile_smooth,
+            xy_profile_include_soma=xy_profile_include_soma,
+            xy_profile_voxel_size=xy_profile_voxel_size,
+            radius_metric=radius_metric,
             backward_compatible=backward_compatible,
             skeleton_nodes_scale=skeleton_nodes_scale,
             verbose=self.verbose,
@@ -1250,10 +1279,15 @@ class Warper:
         z_profile_extent: list[float | int] | None = None,  # [z_min, z_max]
         z_profile_bin_size: float | int | None = None,
         z_profile_hdr_mass: float | int | None = None,
+        z_profile_include_soma: bool | None = None,
+        z_profile_voxel_size: float | None = None,
         xy_profile_extents: list[float | int]
         | None = None,  # [x_min, x_max, y_min, y_max]
         xy_profile_bin_size: float | int | None = None,
         xy_profile_smooth: float | int | None = None,
+        xy_profile_include_soma: bool | None = None,
+        xy_profile_voxel_size: float | None = None,
+        radius_metric: str | None = None,
     ) -> Skeleton:
         """Renormalize the warped skeleton to the desired ON/OFF SAC positions."""
         if self.warped_skeleton is None:
@@ -1279,30 +1313,57 @@ class Warper:
             meta=self.warped_skeleton.meta.copy(),  # copy metadata
         )
 
-        z_profile = get_z_profile(
-            skel_renormed,
-            extent=z_profile_extent
-            if z_profile_extent is not None
-            else self.warped_skeleton.extra["z_profile"]["extent"],
-            bin_size=z_profile_bin_size
-            if z_profile_bin_size is not None
-            else self.warped_skeleton.extra["z_profile"]["bin_size"],
-            hdr_mass=z_profile_hdr_mass
-            if z_profile_hdr_mass is not None
-            else self.warped_skeleton.extra["z_profile"]["hdr_mass"],
-        )
-        xy_profile = get_xy_profile(
-            skel_renormed,
-            extents=xy_profile_extents
-            if xy_profile_extents is not None
-            else self.warped_skeleton.extra["xy_profile"]["extents"],
-            bin_size=xy_profile_bin_size
-            if xy_profile_bin_size is not None
-            else self.warped_skeleton.extra["xy_profile"]["bin_size"],
-            smooth=xy_profile_smooth
-            if xy_profile_smooth is not None
-            else self.warped_skeleton.extra["xy_profile"]["smooth"],
-        )
+        z_profiles = {
+            measure: get_z_profile(
+                skel_renormed,
+                extent=z_profile_extent
+                if z_profile_extent is not None
+                else self.warped_skeleton.extra["z_profiles"][measure]["extent"],
+                bin_size=z_profile_bin_size
+                if z_profile_bin_size is not None
+                else self.warped_skeleton.extra["z_profiles"][measure]["bin_size"],
+                hdr_mass=z_profile_hdr_mass
+                if z_profile_hdr_mass is not None
+                else self.warped_skeleton.extra["z_profiles"][measure]["hdr_mass"],
+                measure=measure,
+                include_soma=z_profile_include_soma
+                if z_profile_include_soma is not None
+                else self.warped_skeleton.extra["z_profiles"][measure]["include_soma"],
+                voxel_size=z_profile_voxel_size
+                if z_profile_voxel_size is not None
+                else self.warped_skeleton.extra["z_profiles"][measure]["voxel_size"],
+                radius_metric=radius_metric
+                if radius_metric is not None
+                else self.warped_skeleton.extra["z_profiles"][measure]["radius_metric"],
+            )
+            for measure in ["length", "volume"]
+        }
+        xy_profiles = {
+            measure: get_xy_profile(
+                skel_renormed,
+                extents=xy_profile_extents
+                if xy_profile_extents is not None
+                else self.warped_skeleton.extra["xy_profiles"][measure]["extents"],
+                bin_size=xy_profile_bin_size
+                if xy_profile_bin_size is not None
+                else self.warped_skeleton.extra["xy_profiles"][measure]["bin_size"],
+                smooth=xy_profile_smooth
+                if xy_profile_smooth is not None
+                else self.warped_skeleton.extra["xy_profiles"][measure]["smooth"],
+                include_soma=xy_profile_include_soma
+                if xy_profile_include_soma is not None
+                else self.warped_skeleton.extra["xy_profiles"][measure]["include_soma"],
+                voxel_size=xy_profile_voxel_size
+                if xy_profile_voxel_size is not None
+                else self.warped_skeleton.extra["xy_profiles"][measure]["voxel_size"],
+                radius_metric=radius_metric
+                if radius_metric is not None
+                else self.warped_skeleton.extra["xy_profiles"][measure][
+                    "radius_metric"
+                ],
+            )
+            for measure in ["length", "volume"]
+        }
 
         skel_renormed.extra = {
             "prenormed_nodes": self.warped_skeleton.extra[
@@ -1310,8 +1371,8 @@ class Warper:
             ],  # keep the pre-normed warped nodes for future use
             "med_z_on": float(self.warped_skeleton.extra["med_z_on"]),
             "med_z_off": float(self.warped_skeleton.extra["med_z_off"]),
-            "z_profile": z_profile,
-            "xy_profile": xy_profile,
+            "z_profiles": z_profiles,
+            "xy_profiles": xy_profiles,
         }
         skel_renormed.meta.update(
             {

--- a/pywarper/warpers.py
+++ b/pywarper/warpers.py
@@ -29,12 +29,10 @@ Key algorithms
   same numerical output but in fully vectorised NumPy.
 """
 
-
 import time
 from copy import deepcopy
 from importlib import metadata as _metadata
 from pathlib import Path
-from typing import Union
 
 import numpy as np
 import skeliner as sk
@@ -44,6 +42,7 @@ from scipy.ndimage import gaussian_filter
 from scipy.spatial import KDTree
 from scipy.special import i0
 from skeliner.core import Skeleton, _bfs_parents
+from skeliner.dx import _ellipsoid_aabb, _voxelize_union
 
 from .surface import build_mapping, fit_sac_surface
 
@@ -61,12 +60,13 @@ def poly_basis_2d(x: np.ndarray, y: np.ndarray, max_order: int) -> np.ndarray:
          x²,  x·y,  y²,      # order 2
          x³,  x²y, x y², y³, …]
     """
-    cols = [np.ones_like(x), x, y]           # constant + linear
+    cols = [np.ones_like(x), x, y]  # constant + linear
     for order in range(2, max_order + 1):
         for ox in range(order + 1):
             oy = order - ox
             cols.append(x**ox * y**oy)
-    return np.stack(cols, axis=1)            # (N, n_terms)
+    return np.stack(cols, axis=1)  # (N, n_terms)
+
 
 def local_ls_registration(
     nodes: np.ndarray,
@@ -86,39 +86,45 @@ def local_ls_registration(
     # ------------------------------------------------------------------
     # 0.  merge the two bands  -----------------------------------------
     # ------------------------------------------------------------------
-    in_all   = np.vstack((top_input_pos,  bot_input_pos))
-    out_all  = np.vstack((top_output_pos, bot_output_pos))
-    is_top   = np.concatenate((
-        np.ones (len(top_input_pos), dtype=bool),
-        np.zeros(len(bot_input_pos), dtype=bool)
-    ))
+    in_all = np.vstack((top_input_pos, bot_input_pos))
+    out_all = np.vstack((top_output_pos, bot_output_pos))
+    is_top = np.concatenate(
+        (
+            np.ones(len(top_input_pos), dtype=bool),
+            np.zeros(len(bot_input_pos), dtype=bool),
+        )
+    )
 
-    all_xy  = in_all[:, :2]                       # (Mtot, 2)
+    all_xy = in_all[:, :2]  # (Mtot, 2)
 
     # ------------------------------------------------------------------
     # 1.  one KD-tree and a *batched* query
     # ------------------------------------------------------------------
-    query_r = window * np.sqrt(2.0)               # circumscribes rectangle
-    tree    = KDTree(all_xy)
+    query_r = window * np.sqrt(2.0)  # circumscribes rectangle
+    tree = KDTree(all_xy)
     idx_lists = tree.query_ball_point(nodes[:, :2], r=query_r, workers=-1)
 
     # ------------------------------------------------------------------
     # 2.  per-node loop (same math as before)
     # ------------------------------------------------------------------
     for k, (x, y, z) in enumerate(nodes):
-        idx = np.array(idx_lists[k], dtype=int)   # neighbour indices
+        idx = np.array(idx_lists[k], dtype=int)  # neighbour indices
 
         # rectangular mask (identical criterion)
         lx, ux = x - window, x + window
         ly, uy = y - window, y + window
         mask_rect = (
-            (all_xy[idx, 0] >= lx) & (all_xy[idx, 0] <= ux) &
-            (all_xy[idx, 1] >= ly) & (all_xy[idx, 1] <= uy)
+            (all_xy[idx, 0] >= lx)
+            & (all_xy[idx, 0] <= ux)
+            & (all_xy[idx, 1] >= ly)
+            & (all_xy[idx, 1] <= uy)
         )
 
-        idx = idx[mask_rect]                      # inside the rectangle
+        idx = idx[mask_rect]  # inside the rectangle
         if idx.size == 0:
-            print(f"[pywarper] Warning: no neighbours for node {k} at ({x:.2f}, {y:.2f}, {z:.2f})")
+            print(
+                f"[pywarper] Warning: no neighbours for node {k} at ({x:.2f}, {y:.2f}, {z:.2f})"
+            )
             transformed_nodes[k] = nodes[k]
             continue
 
@@ -126,31 +132,36 @@ def local_ls_registration(
         idx_top = idx[is_top[idx]]
         idx_bot = idx[~is_top[idx]]
 
-        in_top,  out_top  = in_all[idx_top],  out_all[idx_top]
-        in_bot,  out_bot  = in_all[idx_bot],  out_all[idx_bot]
+        in_top, out_top = in_all[idx_top], out_all[idx_top]
+        in_bot, out_bot = in_all[idx_bot], out_all[idx_bot]
 
-        this_in  = np.vstack((in_top,  in_bot))
+        this_in = np.vstack((in_top, in_bot))
         this_out = np.vstack((out_top, out_bot))
 
         if this_in.shape[0] < 12:
-            print(f"[pywarper] Warning: not enough neighbours for node {k} at ({x:.2f}, {y:.2f}, {z:.2f})")
+            print(
+                f"[pywarper] Warning: not enough neighbours for node {k} at ({x:.2f}, {y:.2f}, {z:.2f})"
+            )
             transformed_nodes[k] = nodes[k]
             continue
 
         # centre the neighbourhood
         shift_xy = this_in[:, :2].mean(axis=0)
-        xin, yin, zin = (this_in[:, 0] - shift_xy[0],
-                         this_in[:, 1] - shift_xy[1],
-                         this_in[:, 2])
+        xin, yin, zin = (
+            this_in[:, 0] - shift_xy[0],
+            this_in[:, 1] - shift_xy[1],
+            this_in[:, 2],
+        )
 
-        xout, yout, zout = (this_out[:, 0] - shift_xy[0],
-                            this_out[:, 1] - shift_xy[1],
-                            this_out[:, 2])
+        xout, yout, zout = (
+            this_out[:, 0] - shift_xy[0],
+            this_out[:, 1] - shift_xy[1],
+            this_out[:, 2],
+        )
 
         # polynomial basis
-        base_terms = poly_basis_2d(xin, yin, max_order)          # (n_pts, n_terms)
-        X = np.hstack((base_terms, base_terms * zin[:, None]))   # z-modulated
-
+        base_terms = poly_basis_2d(xin, yin, max_order)  # (n_pts, n_terms)
+        X = np.hstack((base_terms, base_terms * zin[:, None]))  # z-modulated
 
         # least-squares solve
         T, _, _, _ = lstsq(X, np.column_stack((xout, yout, zout)), rcond=None)
@@ -168,13 +179,13 @@ def local_ls_registration(
 
     return transformed_nodes
 
+
 def warp_nodes(
-        nodes: np.ndarray,
-        surface_mapping: dict,
-        conformal_jump: int | None = None,
-        backward_compatible: bool = False,
+    nodes: np.ndarray,
+    surface_mapping: dict,
+    conformal_jump: int | None = None,
+    backward_compatible: bool = False,
 ) -> tuple[np.ndarray, float, float]:
-    
     # Unpack mappings and surfaces
     mapped_on = surface_mapping["mapped_on"]
     mapped_off = surface_mapping["mapped_off"]
@@ -186,14 +197,13 @@ def warp_nodes(
         sampled_y_idx = surface_mapping["sampled_y_idx"] + 1
         # this is one ugly hack: thisx and thisy are 1-based in MATLAB
         # but 0-based in Python; the rest of the code is to produce exact
-        # same results as MATLAB given the SAME input, that means thisx and 
-        # thisy needs to be 1-based, but we need to shift it back to 0-based 
+        # same results as MATLAB given the SAME input, that means thisx and
+        # thisy needs to be 1-based, but we need to shift it back to 0-based
         # when slicing
     else:
         sampled_x_idx = surface_mapping["sampled_x_idx"]
         sampled_y_idx = surface_mapping["sampled_y_idx"]
 
-    
     # Convert MATLAB 1-based inclusive ranges to Python slices
     # If thisx/thisy are consecutive integer indices:
     # x_vals = np.arange(thisx[0], thisx[-1] + 1)  # matches [thisx(1):thisx(end)] in MATLAB
@@ -216,45 +226,60 @@ def warp_nodes(
     # Extract the corresponding subregion of the surfaces so it also has shape (len(x_vals), len(y_vals)).
     # In MATLAB: tmpminmesh = thisVZminmesh(xRange, yRange)
     if backward_compatible:
-        on_subsampled_depths =  on_sac_surface[x_vals[:, None]-1, y_vals-1]  # shape (len(x_vals), len(y_vals))
-        off_subsampled_depths = off_sac_surface[x_vals[:, None]-1, y_vals-1]  # shape (len(x_vals), len(y_vals))
+        on_subsampled_depths = on_sac_surface[
+            x_vals[:, None] - 1, y_vals - 1
+        ]  # shape (len(x_vals), len(y_vals))
+        off_subsampled_depths = off_sac_surface[
+            x_vals[:, None] - 1, y_vals - 1
+        ]  # shape (len(x_vals), len(y_vals))
     else:
-        on_subsampled_depths =  on_sac_surface[x_vals[:, None], y_vals]
+        on_subsampled_depths = on_sac_surface[x_vals[:, None], y_vals]
         off_subsampled_depths = off_sac_surface[x_vals[:, None], y_vals]
 
     # Now flatten in column-major order (like MATLAB’s A(:)) to line up with tmpxmesh(:), etc.
-    on_input_pts = np.column_stack([
-        xmesh.ravel(order="F"),
-        ymesh.ravel(order="F"),
-        on_subsampled_depths.ravel(order="F")
-    ]) # old topInputPos
+    on_input_pts = np.column_stack(
+        [
+            xmesh.ravel(order="F"),
+            ymesh.ravel(order="F"),
+            on_subsampled_depths.ravel(order="F"),
+        ]
+    )  # old topInputPos
 
-    off_input_pts = np.column_stack([
-        xmesh.ravel(order="F"),
-        ymesh.ravel(order="F"),
-        off_subsampled_depths.ravel(order="F")
-    ]) # old botInputPos
+    off_input_pts = np.column_stack(
+        [
+            xmesh.ravel(order="F"),
+            ymesh.ravel(order="F"),
+            off_subsampled_depths.ravel(order="F"),
+        ]
+    )  # old botInputPos
 
-    on_output_pts = np.column_stack([
-        mapped_on[:, 0],
-        mapped_on[:, 1],
-        np.median(on_subsampled_depths) * np.ones(mapped_on.shape[0])
-    ])
+    on_output_pts = np.column_stack(
+        [
+            mapped_on[:, 0],
+            mapped_on[:, 1],
+            np.median(on_subsampled_depths) * np.ones(mapped_on.shape[0]),
+        ]
+    )
 
-    off_output_pts = np.column_stack([
-        mapped_off[:, 0],
-        mapped_off[:, 1],
-        np.median(off_subsampled_depths) * np.ones(mapped_off.shape[0])
-    ])
+    off_output_pts = np.column_stack(
+        [
+            mapped_off[:, 0],
+            mapped_off[:, 1],
+            np.median(off_subsampled_depths) * np.ones(mapped_off.shape[0]),
+        ]
+    )
 
     # Apply local least-squares registration to each node
-    warped = local_ls_registration(nodes, on_input_pts, off_input_pts, on_output_pts, off_output_pts)
-    
+    warped = local_ls_registration(
+        nodes, on_input_pts, off_input_pts, on_output_pts, off_output_pts
+    )
+
     # Compute median Z-planes
     med_z_on = np.median(on_subsampled_depths)
     med_z_off = np.median(off_subsampled_depths)
 
     return warped, med_z_on, med_z_off
+
 
 def normalize_nodes(
     nodes: np.ndarray,
@@ -270,12 +295,12 @@ def normalize_nodes(
     space where the ON SAC surface is at `on_sac_pos` and the OFF SAC
     surface is at `off_sac_pos`. The z-coordinates are adjusted based on
     the provided median z-values of the ON and OFF SAC surfaces.
-    
+
     Parameters
     ----------
     nodes : np.ndarray
         (N, 3) array of [x, y, z] coordinates for the nodes to be normalized.
-    med_z_on : float            
+    med_z_on : float
         Median z-value of the ON SAC surface.
     med_z_off : float
         Median z-value of the OFF SAC surface.
@@ -289,7 +314,7 @@ def normalize_nodes(
     -------
     np.ndarray
         (N, 3) array of [x, y, z] coordinates with normalized z-coordinates.
-    """ 
+    """
     normalized_nodes = nodes.copy().astype(float)
 
     # Compute the relative depth of each node
@@ -305,14 +330,16 @@ def normalize_nodes(
 def warp_skeleton(
     skel: Skeleton,
     surface_mapping: dict,
-    voxel_resolution: float | list[float | int] = [1., 1., 1.],
+    voxel_resolution: float | list[float | int] = [1.0, 1.0, 1.0],
     on_sac_pos: float = 0.0,
     off_sac_pos: float = 12.0,
-    z_profile_extent: list[float | int] | None = None, # [z_min, z_max]
-    z_profile_bin_size: float | int = 1.,
+    z_profile_extent: list[float | int] | None = None,  # [z_min, z_max]
+    z_profile_bin_size: float | int = 1.0,
     z_profile_hdr_mass: float | int = 0.95,
-    xy_profile_extents: list[float | int] | None = None, # [x_min, x_max, y_min, y_max]
-    xy_profile_bin_size: float | int = 20.,
+    z_profile_measure: str = "length",  # ["length","area","volume"]
+    z_profile_include_soma: bool = False,
+    xy_profile_extents: list[float | int] | None = None,  # [x_min, x_max, y_min, y_max]
+    xy_profile_bin_size: float | int = 20.0,
     xy_profile_smooth: float = 1.0,
     skeleton_nodes_scale: float = 1.0,
     conformal_jump: int | None = None,
@@ -375,7 +402,9 @@ def warp_skeleton(
        reference planes in further analyses.
     """
 
-    nodes = skel.nodes.astype(float) * skeleton_nodes_scale  # scale to the surface unit, which is often μm
+    nodes = (
+        skel.nodes.astype(float) * skeleton_nodes_scale
+    )  # scale to the surface unit, which is often μm
 
     if verbose:
         print("[pywarper] Warping skeleton...")
@@ -401,43 +430,59 @@ def warp_skeleton(
         print(f"    done in {time.time() - start_time:.2f} seconds.")
 
     normalized_soma = deepcopy(skel.soma)
-    normalized_soma.center = normalized_nodes[0] * voxel_resolution  # soma is at the first node
+    normalized_soma.center = (
+        normalized_nodes[0] * voxel_resolution
+    )  # soma is at the first node
 
     skel_norm = Skeleton(
-        soma   = normalized_soma,
-        nodes  = normalized_nodes * voxel_resolution,
-        edges  = skel.edges,      # same connectivity
-        radii  = skel.radii,      # same radii dict
-        ntype  = skel.ntype,      # same node types (if any) 
-        meta   = skel.meta.copy(), 
+        soma=normalized_soma,
+        nodes=normalized_nodes * voxel_resolution,
+        edges=skel.edges,  # same connectivity
+        radii=skel.radii,  # same radii dict
+        ntype=skel.ntype,  # same node types (if any)
+        meta=skel.meta.copy(),
     )
 
-    z_profile = get_z_profile(skel_norm, extent=z_profile_extent, bin_size=z_profile_bin_size, hdr_mass=z_profile_hdr_mass)
+    z_profile = get_z_profile(
+        skel_norm,
+        extent=z_profile_extent,
+        bin_size=z_profile_bin_size,
+        hdr_mass=z_profile_hdr_mass,
+        measure=z_profile_measure,
+        include_soma=z_profile_include_soma,
+    )
     xy_profile = get_xy_profile(
-        skel_norm, extents=xy_profile_extents, bin_size=xy_profile_bin_size, smooth=xy_profile_smooth
+        skel_norm,
+        extents=xy_profile_extents,
+        bin_size=xy_profile_bin_size,
+        smooth=xy_profile_smooth,
     )
 
     skel_norm.extra = {
-        "prenormed_nodes": warped_nodes * voxel_resolution,  # keep the pre-normed warped nodes for future use
+        "prenormed_nodes": warped_nodes
+        * voxel_resolution,  # keep the pre-normed warped nodes for future use
         "med_z_on": float(med_z_on),
         "med_z_off": float(med_z_off),
         "z_profile": z_profile,
         "xy_profile": xy_profile,
     }
-    skel_norm.meta.update({
-        "pywarper_version": _PYWARPER_VERSION,
-        "warped_at": time.strftime("%Y-%m-%d %H:%M:%S"),
-    })
+    skel_norm.meta.update(
+        {
+            "pywarper_version": _PYWARPER_VERSION,
+            "warped_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+        }
+    )
 
     return skel_norm
 
+
 def warp_mesh(
-    mesh: trimesh.Trimesh, # mostly nm
-    surface_mapping: dict, # mostly μm
+    mesh: trimesh.Trimesh,  # mostly nm
+    surface_mapping: dict,  # mostly μm
     conformal_jump: int | None = None,
-    on_sac_pos: float = 0.0, # μm
-    off_sac_pos: float = 12.0, # μm
-    mesh_vertices_scale: float = 1.0, # scale factor for mesh vertices, e.g., 1e-3 for nm to μm
+    on_sac_pos: float = 0.0,  # μm
+    off_sac_pos: float = 12.0,  # μm
+    mesh_vertices_scale: float = 1.0,  # scale factor for mesh vertices, e.g., 1e-3 for nm to μm
     backward_compatible: bool = False,
     verbose: bool = False,
 ) -> trimesh.Trimesh:
@@ -446,7 +491,9 @@ def warp_mesh(
     of previously computed surface mappings.
     """
 
-    vertices = mesh.vertices.astype(float) * mesh_vertices_scale # scale to the surface unit, which is often μm
+    vertices = (
+        mesh.vertices.astype(float) * mesh_vertices_scale
+    )  # scale to the surface unit, which is often μm
 
     if verbose:
         print("[pywarper] Warping mesh...")
@@ -471,9 +518,10 @@ def warp_mesh(
 
     # Create a new mesh with the warped vertices
     warped_mesh = trimesh.Trimesh(
-        vertices=normalized_vertices / mesh_vertices_scale, # rescale back to original units
+        vertices=normalized_vertices
+        / mesh_vertices_scale,  # rescale back to original units
         faces=mesh.faces,
-        process=False,        # no processing
+        process=False,  # no processing
     )
     warped_mesh.metadata = mesh.metadata.copy()  # copy metadata
     warped_mesh.metadata["med_z_on"] = float(med_z_on)
@@ -489,32 +537,139 @@ def warp_mesh(
 
     return warped_mesh
 
+
 # =====================================================================
 # helpers for get_z_profile()
 # =====================================================================
 
+
 def segment_lengths(skel: Skeleton) -> tuple[np.ndarray, np.ndarray]:
-    """Edge length at every non-root node & its mid-point."""
-    # rebuild parent[] (BFS on undirected edges)
+    """
+    Per-edge cable length at every non-root node & its mid-point.
+
+    Returns
+    -------
+    lengths : (N,)  nonzero only at child nodes (each entry is edge length)
+    mid     : (N,3) midpoints (same convention as before)
+    """
     parent = np.asarray(
-        _bfs_parents(skel.edges, len(skel.nodes), root=0),
-        dtype=np.int64,
+        _bfs_parents(skel.edges, len(skel.nodes), root=0), dtype=np.int64
     )
-    child  = np.where(parent != -1)[0]           # (M,)
-    vec    = skel.nodes[parent[child]] - skel.nodes[child]
+    child = np.where(parent != -1)[0]  # nodes with a parent
 
-    seglen = np.linalg.norm(vec, axis=1)
+    a = skel.nodes[child]  # child coords
+    b = skel.nodes[parent[child]]  # parent coords
+    vec = b - a
+    L = np.linalg.norm(vec, axis=1)  # edge length
 
-    density      = np.zeros(len(skel.nodes))
-    density[child] = seglen
-
+    # midpoints in a full (N,3) array
     mid = skel.nodes.copy()
     mid[child] += 0.5 * vec
-    return density, mid
+
+    lengths = np.zeros(len(skel.nodes), dtype=float)
+    lengths[child] = L
+    return lengths, mid
+
+
+def _z_profile_volume_union(
+    skel: Skeleton,
+    extent: list[float | int] | None,
+    bin_size: float,
+    *,
+    voxel_size: float | None,
+    include_soma: bool,
+    hdr_mass: float,
+) -> dict:
+    """Union-correct z-profile of **volume** via dx._voxelize_union (no double-counting)."""
+    # tight bbox from cable radii; expand with soma AABB only if requested
+    # (mirrors dx.volume/area defaults)
+    # pick a radii metric automatically (only used for bbox & frusta voxelization)
+    radius_metric = skel.recommend_radius()[0]
+    radii = np.asarray(skel.radii[radius_metric], dtype=np.float64).reshape(-1)
+
+    lo_nodes = (skel.nodes - radii[:, None]).min(axis=0)
+    hi_nodes = (skel.nodes + radii[:, None]).max(axis=0)
+    if include_soma and getattr(skel, "soma", None) is not None:
+        slo, shi = _ellipsoid_aabb(skel.soma)
+        lo = np.minimum(lo_nodes, slo)
+        hi = np.maximum(hi_nodes, shi)
+    else:
+        lo, hi = lo_nodes, hi_nodes
+
+    # single union voxelization
+    occ, h, (nx, ny, nz), lo, hi = _voxelize_union(
+        skel, radii, lo, hi, voxel_size=voxel_size, include_soma=include_soma
+    )
+    unit = skel.meta.get("unit", "µm")
+
+    if nz == 0:
+        return {
+            "x": np.array([]),
+            "distribution": np.array([]),
+            "histogram": np.array([]),
+            "extent": [0, 0],
+            "n_bins": 0,
+            "bin_size": bin_size,
+            "hdr": [],
+            "hdr_mass": hdr_mass,
+            "measure": "volume",
+            "y_units": f"{unit}³",
+            "voxel_size": h,
+            "grid_shape": (nx, ny, nz),
+            "include_soma": include_soma,
+        }
+
+    z_centres = lo[2] + (np.arange(nz) + 0.5) * h  # slice centers
+    # per-slice volume (occupied voxels × voxel volume)
+    w = occ.sum(axis=(0, 1)).astype(np.float64) * (h**3)  # (nz,)
+
+    # window
+    if extent is None:
+        z_min, z_max = float(z_centres.min()), float(z_centres.max())
+    else:
+        z_min, z_max = extent
+
+    # histogram bins
+    n_bins = int(np.ceil((z_max - z_min) / bin_size))
+    edges = z_min + np.arange(n_bins + 1) * bin_size
+    edges[-1] = z_max
+
+    z_hist, _ = np.histogram(z_centres, bins=edges, weights=w)
+    tot = w.sum()
+    if z_hist.sum() > 0:
+        z_hist *= tot / z_hist.sum()
+
+    # KB-smoothed density (mass-preserving)
+    centre = (z_min + z_max) / 2.0
+    halfspan = (z_max - z_min) / 2.0
+    z_samples = (z_centres - centre) / max(halfspan, np.finfo(float).eps)
+    z_dist = gridder1d(z_samples / 2.0, w, n_bins)
+    if z_dist.sum() > 0:
+        z_dist *= tot / z_dist.sum()
+
+    x_um = 0.5 * (edges[1:] + edges[:-1])
+    intervals = hdr(x_um, z_dist, mass=hdr_mass)
+
+    return {
+        "x": x_um,
+        "distribution": z_dist,
+        "histogram": z_hist,
+        "extent": [z_min, z_max],
+        "n_bins": n_bins,
+        "bin_size": bin_size,
+        "hdr": intervals,
+        "hdr_mass": hdr_mass,
+        "measure": "volume",
+        "y_units": f"{unit}³",
+        "voxel_size": h,
+        "grid_shape": (nx, ny, nz),
+        "include_soma": include_soma,
+    }
+
 
 def gridder1d(
     z_samples: np.ndarray,
-    density:   np.ndarray,
+    density: np.ndarray,
     n: int,
 ) -> np.ndarray:
     """
@@ -530,7 +685,7 @@ def gridder1d(
     # ------------------------------------------------------------------
     alpha, W, err = 2, 5, 1e-3
     S = int(np.ceil(0.91 / err / alpha))
-    beta = np.pi * np.sqrt((W / alpha * (alpha - 0.5))**2 - 0.8)
+    beta = np.pi * np.sqrt((W / alpha * (alpha - 0.5)) ** 2 - 0.8)
 
     s = np.linspace(-1, 1, 2 * S * W + 1)
     F_kbZ = i0(beta * np.sqrt(1 - s**2))
@@ -541,40 +696,42 @@ def gridder1d(
     # ------------------------------------------------------------------
     Gz = alpha * n
     z = np.arange(-Gz // 2, Gz // 2)
-    arg = (np.pi * W * z / Gz)**2 - beta**2
+    arg = (np.pi * W * z / Gz) ** 2 - beta**2
 
     kbZ = np.empty_like(arg, dtype=float)
     pos, neg = arg > 1e-12, arg < -1e-12
-    kbZ[pos]      = np.sin (np.sqrt(arg[pos]))  / np.sqrt(arg[pos])
-    kbZ[neg]      = np.sinh(np.sqrt(-arg[neg])) / np.sqrt(-arg[neg])
-    kbZ[~(pos|neg)] = 1.0
+    kbZ[pos] = np.sin(np.sqrt(arg[pos])) / np.sqrt(arg[pos])
+    kbZ[neg] = np.sinh(np.sqrt(-arg[neg])) / np.sqrt(-arg[neg])
+    kbZ[~(pos | neg)] = 1.0
     kbZ *= np.sqrt(Gz)
 
     # ------------------------------------------------------------------
     # Oversampled grid and *vectorised* accumulation
     # ------------------------------------------------------------------
     n_os = Gz
-    out  = np.zeros(n_os, dtype=float)
+    out = np.zeros(n_os, dtype=float)
 
-    centre = n_os / 2 + 1                         # 1-based like MATLAB
-    nz = centre + n_os * z_samples                # (N,)
+    centre = n_os / 2 + 1  # 1-based like MATLAB
+    nz = centre + n_os * z_samples  # (N,)
 
     half_w = (W - 1) // 2
-    lz_offsets = np.arange(-half_w, half_w + 1)   # (W,)
+    lz_offsets = np.arange(-half_w, half_w + 1)  # (W,)
 
     # shape manipulations so that the first index is lz (to keep
     # addition order identical to the original loop)
-    nz_mat   = nz[None, :] + lz_offsets[:, None]          # (W, N)
-    nzt      = np.round(nz_mat).astype(int)               # (W, N)
-    zpos_mat = S * ((nz[None, :] - nzt) + W / 2)          # (W, N)
-    kw_mat   = F_kbZ[np.round(zpos_mat).astype(int)]      # (W, N)
+    nz_mat = nz[None, :] + lz_offsets[:, None]  # (W, N)
+    nzt = np.round(nz_mat).astype(int)  # (W, N)
+    zpos_mat = S * ((nz[None, :] - nzt) + W / 2)  # (W, N)
+    kw_mat = F_kbZ[np.round(zpos_mat).astype(int)]  # (W, N)
 
-    nzt_clipped = np.clip(nzt, 0, n_os - 1)               # (W, N)
-    np.add.at(out,
-              nzt_clipped.ravel(order="C"),               # lz-major order
-              (density[None, :] * kw_mat).ravel(order="C"))
+    nzt_clipped = np.clip(nzt, 0, n_os - 1)  # (W, N)
+    np.add.at(
+        out,
+        nzt_clipped.ravel(order="C"),  # lz-major order
+        (density[None, :] * kw_mat).ravel(order="C"),
+    )
 
-    out[0] = out[-1] = 0.0                                # edge artefacts
+    out[0] = out[-1] = 0.0  # edge artefacts
 
     # ------------------------------------------------------------------
     # myifft  →  de-apodise  →  abs(myfft3)  (unchanged)
@@ -587,101 +744,105 @@ def gridder1d(
     F = np.fft.fftshift(np.fft.fftn(np.fft.fftshift(f))) / np.sqrt(f.size)
     return np.abs(F)
 
+
 # =====================================================================
 # helpers for get_z_profile() END
 # =====================================================================
 
+
 def get_z_profile(
     skel: Skeleton,
     extent: list[float | int] | None = None,
-    bin_size: float = 1, # µm
+    bin_size: float = 1,  # µm
     hdr_mass: float = 0.95,
+    *,
+    measure: str = "length",  # ["length", "area", "volume"]
+    voxel_size: float | None = None,  # only used for area/volume (union)
+    include_soma: bool = False,
 ) -> dict:
     """
-    Compute a 1-D depth profile (length per z-bin) from a warped skeleton.
+    Compute a 1‑D depth profile.
 
-    Parameters
-    ----------
-    skel
-        Dict returned by ``warp_skeleton()``. Must contain
-            'nodes'   – (N, 3) xyz coordinates in µm,
-            'edges'   – (E, 2) SWC child/parent pairs (1-based),
-            'medVZmin', 'medVZmax'  – median of the ON and OFF SAC surfaces.
-    extent
-        Two floats or ints ``[z_min, z_max]`` that define *one* common physical
-        span (µm) for **all** cells *after* the ON/OFF anchoring.
-        •  Default ``None`` means “just enough to cover the deepest /
-           shallowest point of *this* cell” (original behaviour).  
-        •  Example  ``z_window = (-6.0, 18.0)``  keeps a 6-µm margin on
-           both sides of the SAC band while still centring it at 0–12 µm.
-    nbins
-        Number of evenly-spaced output bins along z.
+    measure:
+        "length" – cable length per bin (histogram + KB‑smoothed).
+        "area"   – **union‑correct** membrane surface area per bin (voxel union).
+        "volume" – **union‑correct** morphology volume per bin (voxel union).
 
-    Returns
-    -------
-    x_um
-        Bin centres in micrometres (depth in IPL).
-    z_dist
-        Dendritic length contained in each bin (same units as input nodes).
-    z_hist
-        Histogram-based Dendritic length (same units as input nodes).
-    z_window
-        The actual z-window used for this cell, in the form
-        ``[z_min, z_max]`` (µm).  If ``z_window`` was not specified,
-        this will be the auto-computed span.
+    Notes
+    -----
+    * Area/volume use a single voxelization (dx._voxelize_union) and
+      **do not double count** at branch junctions or soma contacts.
+    * 'include_soma' defaults to False to match the 'length' convention
+      (edges only). Set True if you want soma membrane/volume included.
+    * For stable plots, keep bin_size ≥ voxel_size (if you set voxel_size).
     """
+    if measure == "length":
+        density, nodes = segment_lengths(skel)
+        z_vals = nodes[:, 2]
 
-    # 0) decide the common span
-    density, nodes = segment_lengths(skel)
+        # window
+        if extent is None:
+            z_min, z_max = np.floor(z_vals.min()), np.ceil(z_vals.max())
+        else:
+            z_min, z_max = extent
 
-    z_vals = nodes[:, 2] # physical z-coordinates (µm)
-    if extent is None:
-        z_min, z_max = np.floor(z_vals.min()), np.ceil(z_vals.max())
-    else:
-        z_min, z_max = extent
+        # histogram bins
+        n_bins = int(np.ceil((z_max - z_min) / bin_size))
+        edges = z_min + np.arange(n_bins + 1) * bin_size
+        edges[-1] = z_max
 
-    # 1) bin edges -------------------------------------------------------------
-    n_bins = int(np.ceil((z_max - z_min) / bin_size))
-    bin_edges = z_min + np.arange(n_bins + 1) * bin_size
-    bin_edges[-1] = z_max                         # clip, never exceed window
+        # histogram (mass-preserving)
+        z_hist, _ = np.histogram(z_vals, bins=edges, weights=density)
+        if z_hist.sum() > 0:
+            z_hist *= density.sum() / z_hist.sum()
 
-    # 2) histogram -------------------------------------------------------------
-    z_hist, _ = np.histogram(z_vals, bins=bin_edges, weights=density)
-    z_hist *= density.sum() / (z_hist.sum())
+        # Kaiser–Bessel gridding (centre to [-1,1], then /2 → [-0.5,0.5])
+        centre = (z_min + z_max) / 2.0
+        halfspan = (z_max - z_min) / 2.0
+        z_samples = (z_vals - centre) / max(halfspan, np.finfo(float).eps)
+        z_dist = gridder1d(z_samples / 2.0, density, n_bins)
+        if z_dist.sum() > 0:
+            z_dist *= density.sum() / z_dist.sum()
 
-    # 3) Kaiser–Bessel gridding (needs centred –0.5 … 0.5) --------------------
-    centre = (z_min + z_max) / 2
-    halfspan = (z_max - z_min) / 2
-    z_samples = (z_vals - centre) / halfspan # now in [-1, 1]
+        x_um = 0.5 * (edges[1:] + edges[:-1])
+        intervals = hdr(x_um, z_dist, mass=hdr_mass)
+        unit = skel.meta.get("unit", "µm")
 
-    z_dist = gridder1d(z_samples / 2, density, n_bins)  # /2 → [-0.5, 0.5]
-    z_dist *= density.sum() / (z_dist.sum())
-
-     # 4) centres & HDR ---------------------------------------------------------
-    x_um = 0.5 * (bin_edges[1:] + bin_edges[:-1])  # centre of each bin
-    hdr_intervals = hdr(x_um, z_dist, mass=hdr_mass)
-
-    res = {
+        return {
             "x": x_um,
             "distribution": z_dist,
             "histogram": z_hist,
             "extent": [z_min, z_max],
             "n_bins": n_bins,
             "bin_size": bin_size,
-            "hdr": hdr_intervals,
+            "hdr": intervals,
             "hdr_mass": hdr_mass,
+            "measure": "length",
+            "y_units": unit,
         }
 
-    return res
+    if measure == "volume":
+        return _z_profile_volume_union(
+            skel,
+            extent,
+            bin_size,
+            voxel_size=voxel_size,
+            include_soma=include_soma,
+            hdr_mass=hdr_mass,
+        )
+
+    raise ValueError("measure must be one of {'length','volume'}")
+
 
 def _edges_from_bin_size(lo: float, hi: float, bin_size: float) -> np.ndarray:
     """Generate edges ≥ bin_size wide, last bin clipped to *hi*."""
     n = int(np.ceil((hi - lo) / bin_size))
     edges = lo + np.arange(n + 1) * bin_size
-    edges[-1] = hi                                      # ensure inclusion
+    edges[-1] = hi  # ensure inclusion
     eps = np.finfo(float).eps
-    edges[-1] += eps * max(1.0, abs(edges[-1]))         # numeric cushion
+    edges[-1] += eps * max(1.0, abs(edges[-1]))  # numeric cushion
     return edges
+
 
 def get_xy_profile(
     skel: Skeleton,
@@ -719,10 +880,10 @@ def get_xy_profile(
         ymin, ymax = y_all.min(), y_all.max()
 
         xmin = np.floor(xmin / bin_size) * bin_size
-        xmax = np.ceil (xmax / bin_size) * bin_size
+        xmax = np.ceil(xmax / bin_size) * bin_size
         ymin = np.floor(ymin / bin_size) * bin_size
-        ymax = np.ceil (ymax / bin_size) * bin_size
-        
+        ymax = np.ceil(ymax / bin_size) * bin_size
+
     else:
         xmin, xmax, ymin, ymax = extents
 
@@ -731,9 +892,7 @@ def get_xy_profile(
     y_edges = _edges_from_bin_size(ymin, ymax, bin_size)
 
     xy_hist, _, _ = np.histogram2d(
-        mid[:, 0], mid[:, 1],
-        bins=[x_edges, y_edges],
-        weights=density
+        mid[:, 0], mid[:, 1], bins=[x_edges, y_edges], weights=density
     )
 
     xy_dist = gaussian_filter(xy_hist, sigma=smooth, mode="nearest")
@@ -748,10 +907,11 @@ def get_xy_profile(
         "distribution": xy_dist,
         "histogram": xy_hist,
         "extents": [x_edges[0], x_edges[-1], y_edges[0], y_edges[-1]],
-        "n_bins": (len(x) , len(y)),     # may differ if dx ≠ dy
+        "n_bins": (len(x), len(y)),  # may differ if dx ≠ dy
         "bin_size": bin_size,
         "smooth": smooth,
     }
+
 
 def hdr(z_centres, z_density, mass=0.95):
     """
@@ -769,8 +929,8 @@ def hdr(z_centres, z_density, mass=0.95):
     [array([ -2.1,  1.7]),   # ON sheet
      array([ 10.3, 13.9])]   # OFF sheet
     """
-    p = z_density / z_density.sum()          # normalise → probability
-    order = np.argsort(p)[::-1]              # bins from high to low density
+    p = z_density / z_density.sum()  # normalise → probability
+    order = np.argsort(p)[::-1]  # bins from high to low density
 
     selected = []
     cum = 0.0
@@ -780,14 +940,15 @@ def hdr(z_centres, z_density, mass=0.95):
         if cum >= mass:
             break
 
-    sel = np.sort(selected)                 # ascending bin indices
+    sel = np.sort(selected)  # ascending bin indices
     # split where gaps > 1 bin
     gaps = np.where(np.diff(sel) > 1)[0]
     groups = [g for g in np.split(sel, gaps + 1)]
 
-    intervals = [np.array([z_centres[g[0]], z_centres[g[-1]]]) for g in groups if len(g) > 0]
+    intervals = [
+        np.array([z_centres[g[0]], z_centres[g[-1]]]) for g in groups if len(g) > 0
+    ]
     return intervals
-
 
 
 class Warper:
@@ -795,14 +956,17 @@ class Warper:
 
     def __init__(
         self,
-        off_sac_points: dict[str, np.ndarray] | tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
-        on_sac_points : dict[str, np.ndarray] | tuple[np.ndarray, np.ndarray, np.ndarray] | None = None,
+        off_sac_points: dict[str, np.ndarray]
+        | tuple[np.ndarray, np.ndarray, np.ndarray]
+        | None = None,
+        on_sac_points: dict[str, np.ndarray]
+        | tuple[np.ndarray, np.ndarray, np.ndarray]
+        | None = None,
         swc_path: str | None = None,
         *,
         voxel_resolution: list[float] = [1.0, 1.0, 1.0],
         verbose: bool = False,
     ) -> None:
-
         self.voxel_resolution = voxel_resolution
         self.verbose = verbose
         self.swc_path = swc_path
@@ -810,11 +974,11 @@ class Warper:
         if off_sac_points is not None:
             self.off_sac_points = self._as_xyz(off_sac_points)
         if on_sac_points is not None:
-            self.on_sac_points  = self._as_xyz(on_sac_points)
+            self.on_sac_points = self._as_xyz(on_sac_points)
 
         if swc_path is not None:
             self.swc_path = swc_path
-            self.load_swc(swc_path)          # raw SWC → self.nodes / edges / radii
+            self.load_swc(swc_path)  # raw SWC → self.nodes / edges / radii
         else:
             self.swc_path = None
 
@@ -836,13 +1000,15 @@ class Warper:
         return self
 
     @staticmethod
-    def _as_xyz(data) -> tuple[np.ndarray, np.ndarray, np.ndarray]: # for load_sac()
+    def _as_xyz(data) -> tuple[np.ndarray, np.ndarray, np.ndarray]:  # for load_sac()
         """Accept *dict* or tuple and return *(x, y, z)* numpy arrays."""
         if isinstance(data, dict):
             return np.asarray(data["x"]), np.asarray(data["y"]), np.asarray(data["z"])
         if isinstance(data, (tuple, list)) and len(data) == 3:
             return map(np.asarray, data)  # type: ignore[arg-type]
-        raise TypeError("SAC data must be a mapping with keys x/y/z or a 3‑tuple of arrays.")
+        raise TypeError(
+            "SAC data must be a mapping with keys x/y/z or a 3‑tuple of arrays."
+        )
 
     def load_sac(self, off_sac_points, on_sac_points) -> "Warper":
         """Load the SAC meshes from *off_sac_points* and *on_sac_points*."""
@@ -852,10 +1018,11 @@ class Warper:
         self.on_sac_points = self._as_xyz(on_sac_points)
         return self
 
-    def load_warped_skeleton(self, 
-            filepath: str,
-            med_z_on: float | None = None,
-            med_z_off: float | None = None,
+    def load_warped_skeleton(
+        self,
+        filepath: str,
+        med_z_on: float | None = None,
+        med_z_off: float | None = None,
     ) -> None:
         """Load a warped skeleton from *swc_path*."""
         path = Path(filepath)
@@ -871,59 +1038,67 @@ class Warper:
                 self.warped_skeleton.extra["med_z_off"] = None
         elif path.suffix.lower() == ".npz":
             self.warped_skeleton = sk.io.load_npz(path)
-            
+
         if self.verbose:
             print(f"[pywarper] Loaded warped skeleton → {path}")
 
     # ---------------------------- Core -----------------------------------
 
-    def fit_surfaces(self, 
-                     xmax:int | float | None = None, 
-                     ymax:int | float | None= None, 
-                     stride:int = 3, 
-                     smoothness: int = 15, 
-                     backward_compatible:bool=False
-     ) -> "Warper":
+    def fit_surfaces(
+        self,
+        xmax: int | float | None = None,
+        ymax: int | float | None = None,
+        stride: int = 3,
+        smoothness: int = 15,
+        backward_compatible: bool = False,
+    ) -> "Warper":
         """Fit ON / OFF SAC meshes with *pygridfit*."""
         if self.verbose:
             print("[pywarper] Fitting SAC surfaces …")
 
         if backward_compatible is False and (xmax is None or ymax is None):
             # use the bounding box of the skeleton
-            xmax=max(self.off_sac_points[0].max(), self.on_sac_points[0].max())
-            ymax=max(self.off_sac_points[1].max(), self.on_sac_points[1].max())
+            xmax = max(self.off_sac_points[0].max(), self.on_sac_points[0].max())
+            ymax = max(self.off_sac_points[1].max(), self.on_sac_points[1].max())
 
         _t0 = time.time()
         self.off_sac_surface, *_ = fit_sac_surface(
-            x=self.off_sac_points[0], 
+            x=self.off_sac_points[0],
             y=self.off_sac_points[1],
-            z=self.off_sac_points[2], 
+            z=self.off_sac_points[2],
             stride=stride,
             smoothness=smoothness,
-            xmax=xmax, ymax=ymax,
+            xmax=xmax,
+            ymax=ymax,
             backward_compatible=backward_compatible,
         )
         if self.verbose:
-            print(f"↳ fitting OFF (max) surface\n    done in {time.time() - _t0:.2f} seconds.")
-        
+            print(
+                f"↳ fitting OFF (max) surface\n    done in {time.time() - _t0:.2f} seconds."
+            )
+
         _t0 = time.time()
         self.on_sac_surface, *_ = fit_sac_surface(
-            x=self.on_sac_points[0], 
-            y=self.on_sac_points[1], 
-            z=self.on_sac_points[2], 
+            x=self.on_sac_points[0],
+            y=self.on_sac_points[1],
+            z=self.on_sac_points[2],
             smoothness=smoothness,
-            xmax=xmax, ymax=ymax,
+            xmax=xmax,
+            ymax=ymax,
             backward_compatible=backward_compatible,
         )
         if self.verbose:
-            print(f"↳ fitting ON (min) surface\n    done in {time.time() - _t0:.2f} seconds.")
+            print(
+                f"↳ fitting ON (min) surface\n    done in {time.time() - _t0:.2f} seconds."
+            )
         return self
 
-    def build_mapping(self, 
-                      bounds: np.ndarray | tuple | str | None = "local",
-                      conformal_jump: int = 2, 
-                      n_anchors: int = 16,
-                      backward_compatible: bool = False,
+    def build_mapping(
+        self,
+        bounds: np.ndarray | tuple | str | None = "local",
+        conformal_jump: int = 2,
+        n_anchors: int = 16,
+        backward_compatible: bool = False,
     ) -> "Warper":
         """Create the quasi‑conformal surface mapping."""
         if self.off_sac_surface is None or self.on_sac_surface is None:
@@ -932,8 +1107,14 @@ class Warper:
         if bounds is None or bounds == "local":
             # skeleton-derived box (rounded to int so it plays nicely with
             # backward-compatible 1-based code paths)
-            xmin, xmax = self.skeleton.nodes[:, 0].min(), self.skeleton.nodes[:, 0].max()
-            ymin, ymax = self.skeleton.nodes[:, 1].min(), self.skeleton.nodes[:, 1].max()
+            xmin, xmax = (
+                self.skeleton.nodes[:, 0].min(),
+                self.skeleton.nodes[:, 0].max(),
+            )
+            ymin, ymax = (
+                self.skeleton.nodes[:, 1].min(),
+                self.skeleton.nodes[:, 1].max(),
+            )
             bounds = np.array([xmin, xmax, ymin, ymax], dtype=float)
         elif bounds == "global":
             # use whichever SAC fit is larger in each axis
@@ -943,8 +1124,10 @@ class Warper:
         else:
             bounds = np.asarray(bounds, dtype=float)
             if bounds.shape != (4,):
-                raise ValueError("Bounds must be a 4‑element array or tuple (x_min, x_max, y_min, y_max).")
-        
+                raise ValueError(
+                    "Bounds must be a 4‑element array or tuple (x_min, x_max, y_min, y_max)."
+                )
+
         if self.verbose:
             print("[pywarper] Building mapping …")
         self.mapping: dict = build_mapping(
@@ -958,22 +1141,25 @@ class Warper:
         )
         return self
 
-    def warp_skeleton(self, 
-                z_profile_extent: list[float | int] | None = None,
-                z_profile_bin_size: float | int = 1, # um
-                z_profile_hdr_mass: float | int = 0.95,
-                xy_profile_extents: list[float | int] | None = None,
-                xy_profile_bin_size: float | int = 20, # um
-                xy_profile_smooth: float | int = 1.,
-                skeleton_nodes_scale: float = 1.0,
-                voxel_resolution: list[float | int] | None = None, 
-                conformal_jump: int | None = None,
-                backward_compatible: bool = False,
+    def warp_skeleton(
+        self,
+        z_profile_extent: list[float | int] | None = None,
+        z_profile_bin_size: float | int = 1,  # um
+        z_profile_hdr_mass: float | int = 0.95,
+        z_profile_measure: str = "length",  # ["length","area","volume"]
+        z_profile_include_soma: bool = False,
+        xy_profile_extents: list[float | int] | None = None,
+        xy_profile_bin_size: float | int = 20,  # um
+        xy_profile_smooth: float | int = 1.0,
+        skeleton_nodes_scale: float = 1.0,
+        voxel_resolution: list[float | int] | None = None,
+        conformal_jump: int | None = None,
+        backward_compatible: bool = False,
     ) -> "Warper":
         """Apply the mapping to the skeleton."""
         if self.mapping is None:
             raise RuntimeError("Mapping missing. Call build_mapping() first.")
-        
+
         if voxel_resolution is None:
             voxel_resolution = self.voxel_resolution
 
@@ -985,6 +1171,8 @@ class Warper:
             z_profile_extent=z_profile_extent,
             z_profile_bin_size=z_profile_bin_size,
             z_profile_hdr_mass=z_profile_hdr_mass,
+            z_profile_measure=z_profile_measure,
+            z_profile_include_soma=z_profile_include_soma,
             xy_profile_extents=xy_profile_extents,
             xy_profile_bin_size=xy_profile_bin_size,
             xy_profile_smooth=xy_profile_smooth,
@@ -993,15 +1181,16 @@ class Warper:
             verbose=self.verbose,
         )
         return self
-    
 
-    def renormalize(self, 
+    def renormalize(
+        self,
         on_sac_pos: float = 0.0,
         off_sac_pos: float = 12.0,
-        z_profile_extent: list[float | int] | None = None, # [z_min, z_max]
+        z_profile_extent: list[float | int] | None = None,  # [z_min, z_max]
         z_profile_bin_size: float | int | None = None,
         z_profile_hdr_mass: float | int | None = None,
-        xy_profile_extents: list[float | int] | None = None, # [x_min, x_max, y_min, y_max]
+        xy_profile_extents: list[float | int]
+        | None = None,  # [x_min, x_max, y_min, y_max]
         xy_profile_bin_size: float | int | None = None,
         xy_profile_smooth: float | int | None = None,
     ) -> Skeleton:
@@ -1021,38 +1210,53 @@ class Warper:
         soma_renormed.center = renormed_nodes[0] * self.voxel_resolution
 
         skel_renormed = Skeleton(
-            soma   = soma_renormed,
-            nodes  = renormed_nodes,
-            edges  = self.warped_skeleton.edges,     
-            radii  = self.warped_skeleton.radii,      
-            ntype  = self.warped_skeleton.ntype,
-            meta = self.warped_skeleton.meta.copy(),  # copy metadata
+            soma=soma_renormed,
+            nodes=renormed_nodes,
+            edges=self.warped_skeleton.edges,
+            radii=self.warped_skeleton.radii,
+            ntype=self.warped_skeleton.ntype,
+            meta=self.warped_skeleton.meta.copy(),  # copy metadata
         )
 
         z_profile = get_z_profile(
-            skel_renormed, 
-            extent=z_profile_extent if z_profile_extent is not None else self.warped_skeleton.extra["z_profile"]["extent"],
-            bin_size=z_profile_bin_size if z_profile_bin_size is not None else self.warped_skeleton.extra["z_profile"]["bin_size"],
-            hdr_mass=z_profile_hdr_mass if z_profile_hdr_mass is not None else self.warped_skeleton.extra["z_profile"]["hdr_mass"],
+            skel_renormed,
+            extent=z_profile_extent
+            if z_profile_extent is not None
+            else self.warped_skeleton.extra["z_profile"]["extent"],
+            bin_size=z_profile_bin_size
+            if z_profile_bin_size is not None
+            else self.warped_skeleton.extra["z_profile"]["bin_size"],
+            hdr_mass=z_profile_hdr_mass
+            if z_profile_hdr_mass is not None
+            else self.warped_skeleton.extra["z_profile"]["hdr_mass"],
         )
         xy_profile = get_xy_profile(
-            skel_renormed, 
-            extents=xy_profile_extents if xy_profile_extents is not None else self.warped_skeleton.extra["xy_profile"]["extents"],
-            bin_size=xy_profile_bin_size if xy_profile_bin_size is not None else self.warped_skeleton.extra["xy_profile"]["bin_size"],
-            smooth=xy_profile_smooth if xy_profile_smooth is not None else self.warped_skeleton.extra["xy_profile"]["smooth"],
-        ) 
+            skel_renormed,
+            extents=xy_profile_extents
+            if xy_profile_extents is not None
+            else self.warped_skeleton.extra["xy_profile"]["extents"],
+            bin_size=xy_profile_bin_size
+            if xy_profile_bin_size is not None
+            else self.warped_skeleton.extra["xy_profile"]["bin_size"],
+            smooth=xy_profile_smooth
+            if xy_profile_smooth is not None
+            else self.warped_skeleton.extra["xy_profile"]["smooth"],
+        )
 
         skel_renormed.extra = {
-            "prenormed_nodes": self.warped_skeleton.extra["prenormed_nodes"], # keep the pre-normed warped nodes for future use
-            "med_z_on":  float(self.warped_skeleton.extra["med_z_on"]),
+            "prenormed_nodes": self.warped_skeleton.extra[
+                "prenormed_nodes"
+            ],  # keep the pre-normed warped nodes for future use
+            "med_z_on": float(self.warped_skeleton.extra["med_z_on"]),
             "med_z_off": float(self.warped_skeleton.extra["med_z_off"]),
             "z_profile": z_profile,
             "xy_profile": xy_profile,
         }
-        skel_renormed.meta.update({
-            "pywarper_version": _PYWARPER_VERSION,
-            "renormed_at": time.strftime("%Y-%m-%d %H:%M:%S"),
-        })
+        skel_renormed.meta.update(
+            {
+                "pywarper_version": _PYWARPER_VERSION,
+                "renormed_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+            }
+        )
 
         return skel_renormed
-

--- a/pywarper/warpers.py
+++ b/pywarper/warpers.py
@@ -539,7 +539,7 @@ def warp_mesh(
 
 
 # =====================================================================
-# helpers for get_z_profile()
+# helpers for get_z_profile() and get_xy_profile()
 # =====================================================================
 
 
@@ -571,7 +571,7 @@ def segment_lengths(skel: Skeleton) -> tuple[np.ndarray, np.ndarray]:
     return lengths, mid
 
 
-def segment_volumes(
+def z_slince_volumes(
     skel: Skeleton,
     *,
     voxel_size: float | None = None,
@@ -579,11 +579,7 @@ def segment_volumes(
     radius_metric: str | None = None,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
-    Union‑correct *per‑z slice* volumes as weights + sample positions.
-
-    This mirrors `segment_lengths()` in return shape, but the notion of a
-    “segment” here is a **z‑slice of the union** (frusta + optional soma),
-    not an edge.
+    Union-correct **per-z slice** volumes as weights + sample positions.
 
     Returns
     -------
@@ -592,13 +588,6 @@ def segment_volumes(
     mid     : (K, 3) float
         Sample positions for each slice: (x̄, ȳ, z_center), where x̄,ȳ are
         slice area‑weighted centroids and z_center is the slice center.
-
-    Notes
-    -----
-    * Uses `dx._voxelize_union` once; no double counting at branch junctions
-      or soma contacts.
-    * If you don't care about x̄,ȳ, you can replace them with zeros to save
-      a tiny bit of compute; z‑profiles only use `mid[:,2]`.
     """
     # choose radii column for voxelizer / bbox
     if radius_metric is None:
@@ -649,6 +638,68 @@ def segment_volumes(
         ybar = np.where(counts > 0, sum_y / counts, (lo[1] + hi[1]) / 2.0)
 
     mid = np.column_stack((xbar, ybar, zc)).astype(np.float64)
+    return vol, mid
+
+
+def xy_column_volume(
+    skel: Skeleton,
+    *,
+    voxel_size: float | None = None,
+    include_soma: bool = False,
+    radius_metric: str | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Union-correct **per-(x,y) column** volumes + sample positions.
+
+    Returns
+    -------
+    vol : (K,) float
+        Volume in each non-empty (x,y) column (integrated over z), unit³.
+    mid : (K,3) float
+        (x_center, y_center, z̄) for that column, where z̄ is the z-centroid
+        of occupied voxels in the column (handy but not used by XY maps).
+    """
+    if radius_metric is None:
+        radius_metric = skel.recommend_radius()[0]
+    radii = np.asarray(skel.radii[radius_metric], dtype=np.float64).reshape(-1)
+
+    lo_nodes = (skel.nodes - radii[:, None]).min(axis=0)
+    hi_nodes = (skel.nodes + radii[:, None]).max(axis=0)
+    if include_soma and getattr(skel, "soma", None) is not None:
+        slo, shi = _ellipsoid_aabb(skel.soma)
+        lo = np.minimum(lo_nodes, slo)
+        hi = np.maximum(hi_nodes, shi)
+    else:
+        lo, hi = lo_nodes, hi_nodes
+
+    occ, h, (nx, ny, nz), lo, hi = _voxelize_union(
+        skel, radii, lo, hi, voxel_size=voxel_size, include_soma=include_soma
+    )
+    if nx == 0 or ny == 0:
+        return np.zeros(0), np.zeros((0, 3))
+
+    # volume per (x,y) column
+    vol_xy = occ.sum(axis=2).astype(np.float64) * (h**3)  # (nx, ny)
+    mask = vol_xy > 0.0
+    if not mask.any():
+        return np.zeros(0), np.zeros((0, 3))
+
+    # centers
+    xs = lo[0] + (np.arange(nx) + 0.5) * h
+    ys = lo[1] + (np.arange(ny) + 0.5) * h
+    Xc, Yc = np.meshgrid(xs, ys, indexing="ij")
+
+    # z centroid per column (nice to have)
+    zc = lo[2] + (np.arange(nz) + 0.5) * h  # (nz,)
+    occ_flat = occ.reshape(nx * ny, nz).astype(np.float64)
+    counts = occ_flat.sum(axis=1)  # (#columns,)
+    sum_z = occ_flat @ zc  # (#columns,)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        zbar = np.where(counts > 0, sum_z / counts, (lo[2] + hi[2]) / 2.0)
+    zbar = zbar.reshape(nx, ny)
+
+    vol = vol_xy[mask]
+    mid = np.column_stack((Xc[mask], Yc[mask], zbar[mask])).astype(np.float64)
     return vol, mid
 
 
@@ -765,7 +816,7 @@ def get_z_profile(
     if measure == "length":
         density, nodes = segment_lengths(skel)
     elif measure == "volume":
-        density, nodes = segment_volumes(
+        density, nodes = z_slince_volumes(
             skel,
             voxel_size=voxel_size,
             include_soma=include_soma,
@@ -835,6 +886,11 @@ def get_xy_profile(
     extents: list[float | int] | None = None,
     bin_size: float | int = 2.0,
     smooth: float | int = 1.0,
+    *,
+    measure: str = "length",  # {"length","volume"}
+    radius_metric: str | None = None,
+    voxel_size: float | None = None,
+    include_soma: bool = False,
 ) -> dict:
     """
     Planar (x-y) dendritic-length density on a **square** grid.
@@ -849,6 +905,10 @@ def get_xy_profile(
         exactly `bin_size` wide.  (This guarantees comparability.)
     smooth
         σ of the Gaussian kernel (bins) applied to the histogram.
+    measure:
+        "length" – dendritic cable length per bin (histogram → Gaussian smooth).
+        "volume" – **union-correct** morphology volume per bin (voxel union),
+                   integrated along z, then binned in x-y.
 
     Returns
     -------
@@ -856,7 +916,19 @@ def get_xy_profile(
            ``histogram`` (raw), ``extents``, ``bin_size``, ``nbins`` …
     """
 
-    density, mid = segment_lengths(skel)
+    if measure == "length":
+        density, mid = segment_lengths(skel)
+        units = skel.meta.get("unit", "µm")
+    elif measure == "volume":
+        density, mid = xy_column_volume(
+            skel,
+            voxel_size=voxel_size,
+            include_soma=include_soma,
+            radius_metric=radius_metric,
+        )
+        units = f"{skel.meta.get('unit', 'µm')}³"
+    else:
+        raise ValueError("measure must be one of {'length','volume'}")
 
     # 0) bounding box ----------------------------------------------------------
     if extents is None:
@@ -896,6 +968,9 @@ def get_xy_profile(
         "n_bins": (len(x), len(y)),  # may differ if dx ≠ dy
         "bin_size": bin_size,
         "smooth": smooth,
+        "measure": measure,
+        "units": units,
+        "include_soma": include_soma,
     }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1038,20 +1038,6 @@ wheels = [
 ]
 
 [[package]]
-name = "openctm"
-version = "0.0.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/bc/827403f7456405b07cc051f9c84271427a1f56261448856f6ed99f9d2c6f/openctm-0.0.6-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:338be75c72076031d41ffe707ebdbc48b61c0a740497c572510e1bd4533d6057", size = 129105, upload-time = "2024-08-21T16:54:20.595Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/2d/3231734252aab2d60841be8fce8d31a6ff6b7dbdc9c3a434c3b1fee1e0ef/openctm-0.0.6-py3-none-manylinux2014_i686.whl", hash = "sha256:d185c4d9f21ccdeab51ca85fa10556c5787b7a24a1e0a285dab281a66410e4fd", size = 101491, upload-time = "2024-08-21T16:54:22.081Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/96/9996538318d05d5dd558743800ccfd0a36ee92040e50f36486b0186b0851/openctm-0.0.6-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c4b3df08e95da6795c65209829090b766db65c476a313f8d66bfed6217f39009", size = 102459, upload-time = "2024-08-21T16:54:23.036Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/14/f573f1f99eb813120925e52f736da83e2627f1df73dc8f014e53b1030e65/openctm-0.0.6-py3-none-win_amd64.whl", hash = "sha256:8af2b04d869d7dc2216f4ca4199f2f65ea0a9a693905ef27724682f903cc273c", size = 224804, upload-time = "2024-08-21T16:54:24.233Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1300,33 +1286,8 @@ wheels = [
 ]
 
 [[package]]
-name = "python-openctm"
-version = "1.0.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/52/16/b169b47321f31ba30bfe5410a48e374b4e12cd7e52685cc6efe97ae46642/python-openctm-1.0.12.tar.gz", hash = "sha256:e348d7df9375ea405df0e85c6b7b9d182d185dd54f21954bed6660d6629c06d9", size = 5069, upload-time = "2023-04-26T14:56:42.035Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/5f/9bf1b41edde35b7c3d55987555ff6ed40e3a978fef52deee90fd6957491c/python_openctm-1.0.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:973a8b4bcf71879fcafcbdd4fafffa3eb3a2944ffcb42ee8b5e140a1eb7aa85e", size = 74683, upload-time = "2023-04-26T14:54:54.725Z" },
-    { url = "https://files.pythonhosted.org/packages/17/a0/ac6612f6324f11832daa72005ba9af08c6c0f6e653b527b4d86c91e18780/python_openctm-1.0.12-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:942a54a3b26822423f85544a03ac72cc3669b7964995f058d2b89757875f4241", size = 72026, upload-time = "2023-04-26T14:54:56.847Z" },
-    { url = "https://files.pythonhosted.org/packages/47/8b/ab9fe347334c17563fe5ebbe1697ed7be5898b51d0dbe8aa595d859838ad/python_openctm-1.0.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9016d8fc9a156d4bac47e29c59974f598c09c7ad27e22bdfe7a83250c2691ffe", size = 75640, upload-time = "2023-04-26T14:54:59.122Z" },
-    { url = "https://files.pythonhosted.org/packages/98/ff/031f660c4682590616b2e08d426d8d49a6fbb8d8efc3e9bee81854f1d089/python_openctm-1.0.12-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:db273c18d9dd0b23ebeaaabdb7966e0454857d5022fd19273a960d8c58c9d3ab", size = 74787, upload-time = "2023-04-26T14:55:01.791Z" },
-    { url = "https://files.pythonhosted.org/packages/91/b4/8a1f3e7625e92346be3627a692a43c3443c5b7a903868935f6cfa12d8ada/python_openctm-1.0.12-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:30a1de71ffd953553baad96a30df69bae9f0d9e2551c6339a61cc84b8aa4e3c1", size = 72588, upload-time = "2023-04-26T14:55:04.84Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/01/8d895eab73d12a34f5c658925c37a4356c9056ac6f11324d21264407d234/python_openctm-1.0.12-cp310-cp310-win32.whl", hash = "sha256:3172333f8269face7c4d33dc97e18de347a45bd905df3dc9ac58ef0333d4b47d", size = 76058, upload-time = "2023-04-26T14:55:07.01Z" },
-    { url = "https://files.pythonhosted.org/packages/02/fc/5d2151916139156f94869ceb5bbc32fcd73ee9e768ee1dae9412c06dbcb9/python_openctm-1.0.12-cp310-cp310-win_amd64.whl", hash = "sha256:4eca6294cbb21b02ebe038cca58325c2e2721583956e3bc9f7fb635a0fd3aa4d", size = 76066, upload-time = "2023-04-26T14:55:09.423Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/d0/769b208fc17dc7d646a7c8e3382dd41b0207d81e9b208d8f0e99a34666a0/python_openctm-1.0.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:940adc68f5bc839d67198c2f71b0a372cbcc8043206f3ead97fcb21bccc04c4c", size = 74683, upload-time = "2023-04-26T14:55:11.299Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/08/ad3d2cd4c072f63b4a9e4fde75c75e12f98d5830269a86f7cc7f72690244/python_openctm-1.0.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f449d9bd82e1404e322f3c1d0f389ede019df1123f7ba6c94ec78d239ce4a67f", size = 72027, upload-time = "2023-04-26T14:55:13.597Z" },
-    { url = "https://files.pythonhosted.org/packages/53/9a/52d4c6348d364acc555312c4f8850a1328c25e4c8d715a835dff17a231d8/python_openctm-1.0.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6e7cdd38b4d7bdef3168868c0af189881db151b523a8cee2138aa5f8bc9f6a79", size = 75640, upload-time = "2023-04-26T14:55:15.063Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/57/3747653726794c11653b4aff8c662baa2c4e715840796e844c1a1f38c021/python_openctm-1.0.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:b1780d490c57f9af5559945cb63722ab323b24d56f06662c4944c890cb38971a", size = 74786, upload-time = "2023-04-26T14:55:17.176Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/56/06c42880dbaa3cb542084af814ba8f0e1688cc32519d1d5ae7b860f2c060/python_openctm-1.0.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:ca7470fe0194c1b3e2670e4e2bbe6f379f30200f9241c4648a00ce43eceb6437", size = 72588, upload-time = "2023-04-26T14:55:18.947Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/69/9b74af15d1c93e051a36dda65b31e7e7f85bdd4024bcb944d6579fdb898d/python_openctm-1.0.12-cp311-cp311-win32.whl", hash = "sha256:8ce6a9a8126c707a5796408089fe0ff5f62042d8bbccecac00934ca903e35663", size = 76060, upload-time = "2023-04-26T14:55:20.696Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/f6/2c1889161ab0d679c6e585e174996cfe9a350a7ff390374feafaffb00ba1/python_openctm-1.0.12-cp311-cp311-win_amd64.whl", hash = "sha256:695783814bf7a620b81cbca3973a3b065d20e0630c2baf9a3a33c4f0b3407342", size = 76066, upload-time = "2023-04-26T14:55:22.46Z" },
-]
-
-[[package]]
 name = "pywarper"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "alphashape" },
@@ -1362,7 +1323,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-sparse", marker = "extra == 'scikit-sparse'", specifier = ">=0.4.15" },
     { name = "scipy", specifier = ">=1.15.0" },
-    { name = "skeliner", specifier = ">=0.1.6" },
+    { name = "skeliner", specifier = ">=0.1.14" },
     { name = "twine", marker = "extra == 'dev'" },
     { name = "watermark", specifier = ">=2.5.0" },
 ]
@@ -1535,19 +1496,18 @@ wheels = [
 
 [[package]]
 name = "rtree"
-version = "1.4.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/b8/0091f020acafcb034daa5b062f0626f6a73c7e0d64826af23861390a9585/rtree-1.4.0.tar.gz", hash = "sha256:9d97c7c5dcf25f6c0599c76d9933368c6a8d7238f2c1d00e76f1a69369ca82a0", size = 50789, upload-time = "2025-03-05T23:31:45.962Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/09/7302695875a019514de9a5dd17b8320e7a19d6e7bc8f85dcfb79a4ce2da3/rtree-1.4.1.tar.gz", hash = "sha256:c6b1b3550881e57ebe530cc6cffefc87cd9bf49c30b37b894065a9f810875e46", size = 52425, upload-time = "2025-08-13T19:32:01.413Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/4c/8d54d6dc5ff8ba8ced1fad9378f89f9dd60addcc4cf0e525ee0e67b1769f/rtree-1.4.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:4d1bebc418101480aabf41767e772dd2155d3b27b1376cccbd93e4509485e091", size = 482755, upload-time = "2025-03-05T23:31:29.884Z" },
-    { url = "https://files.pythonhosted.org/packages/20/29/045e700d2135e9a67896086c831fde80fd4105971b443d5727a4093fcbf1/rtree-1.4.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:997f8c38d5dffa3949ea8adb4c8b291ea5cd4ef5ee69455d642dd171baf9991d", size = 439796, upload-time = "2025-03-05T23:31:31.517Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/fc/c3bd8cd67b10a12a6b9e2d06796779128c3e6968922dbf29fcd53af68d81/rtree-1.4.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0133d9c54ab3ffe874ba6d411dbe0254765c5e68d92da5b91362c370f16fd997", size = 497549, upload-time = "2025-03-05T23:31:33.722Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/dd/49dc9ab037d0cb288ed40f8b7f498f69d44243e4745e241c05d5e457ea8b/rtree-1.4.0-py3-none-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:d3b7bf1fe6463139377995ebe22a01a7005d134707f43672a3c09305e12f5f43", size = 568787, upload-time = "2025-03-05T23:31:35.478Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/e7/57737dff73ce789bdadd916d48ac12e977d8578176e1e890b1b8d89b9dbf/rtree-1.4.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:27e4a6d617d63dcb82fcd4c2856134b8a3741bd1af3b1a0d98e886054f394da5", size = 541090, upload-time = "2025-03-05T23:31:37.712Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/8f/1f3f716c4e8388670cfd5d0a3578e2354a1e6a3403648e234e1540e3e3bd/rtree-1.4.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5258e826064eab82439760201e9421ce6d4340789d6d080c1b49367ddd03f61f", size = 1454194, upload-time = "2025-03-05T23:31:39.851Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ec/b42052b10e63a1c5d5d61ce234332f689736053644ba1756f7a632ea7659/rtree-1.4.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:20d5b3f9cf8bbbcc9fec42ab837c603c5dd86103ef29134300c8da2495c1248b", size = 1692814, upload-time = "2025-03-05T23:31:41.617Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/5b/a9920e9a2dc43b066ff13b7fde2e7bffcca315cfa43ae6f4cc15970e39eb/rtree-1.4.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a67bee1233370a4c72c0969a96d2a1df1ba404ddd9f146849c53ab420eab361b", size = 1554860, upload-time = "2025-03-05T23:31:43.091Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/c2/362f2cc36a7a57b47380061c23fc109c7222c1a544ffd24cda289ba19673/rtree-1.4.0-py3-none-win_amd64.whl", hash = "sha256:ba83efc7b7563905b1bfdfc14490c4bfb59e92e5e6156bdeb6ec5df5117252f4", size = 385221, upload-time = "2025-03-05T23:31:44.537Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d9/108cd989a4c0954e60b3cdc86fd2826407702b5375f6dfdab2802e5fed98/rtree-1.4.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:d672184298527522d4914d8ae53bf76982b86ca420b0acde9298a7a87d81d4a4", size = 468484, upload-time = "2025-08-13T19:31:50.593Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/cf/2710b6fd6b07ea0aef317b29f335790ba6adf06a28ac236078ed9bd8a91d/rtree-1.4.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a7e48d805e12011c2cf739a29d6a60ae852fb1de9fc84220bbcef67e6e595d7d", size = 436325, upload-time = "2025-08-13T19:31:52.367Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e1/4d075268a46e68db3cac51846eb6a3ab96ed481c585c5a1ad411b3c23aad/rtree-1.4.1-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa8c4496e31e9ad58ff6c7df89abceac7022d906cb64a3e18e4fceae6b77f65", size = 459789, upload-time = "2025-08-13T19:31:53.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/75/e5d44be90525cd28503e7f836d077ae6663ec0687a13ba7810b4114b3668/rtree-1.4.1-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12de4578f1b3381a93a655846900be4e3d5f4cd5e306b8b00aa77c1121dc7e8c", size = 507644, upload-time = "2025-08-13T19:31:55.164Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/85/b8684f769a142163b52859a38a486493b05bafb4f2fb71d4f945de28ebf9/rtree-1.4.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b558edda52eca3e6d1ee629042192c65e6b7f2c150d6d6cd207ce82f85be3967", size = 1454478, upload-time = "2025-08-13T19:31:56.808Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a4/c2292b95246b9165cc43a0c3757e80995d58bc9b43da5cb47ad6e3535213/rtree-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f155bc8d6bac9dcd383481dee8c130947a4866db1d16cb6dff442329a038a0dc", size = 1555140, upload-time = "2025-08-13T19:31:58.031Z" },
+    { url = "https://files.pythonhosted.org/packages/74/25/5282c8270bfcd620d3e73beb35b40ac4ab00f0a898d98ebeb41ef0989ec8/rtree-1.4.1-py3-none-win_amd64.whl", hash = "sha256:efe125f416fd27150197ab8521158662943a40f87acab8028a1aac4ad667a489", size = 389358, upload-time = "2025-08-13T19:31:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/50/0a9e7e7afe7339bd5e36911f0ceb15fed51945836ed803ae5afd661057fd/rtree-1.4.1-py3-none-win_arm64.whl", hash = "sha256:3d46f55729b28138e897ffef32f7ce93ac335cb67f9120125ad3742a220800f0", size = 355253, upload-time = "2025-08-13T19:32:00.296Z" },
 ]
 
 [[package]]
@@ -1725,20 +1685,19 @@ wheels = [
 
 [[package]]
 name = "skeliner"
-version = "0.1.6"
+version = "0.1.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "igraph" },
     { name = "matplotlib" },
     { name = "numpy" },
-    { name = "openctm", marker = "python_full_version >= '3.12'" },
-    { name = "python-openctm", marker = "python_full_version < '3.12'" },
+    { name = "rtree" },
     { name = "scipy" },
     { name = "trimesh" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/5a/5b6dbad2fc481edcf119de0fd25d99367c9a5a719eb1721857b77de8c5fe/skeliner-0.1.6.tar.gz", hash = "sha256:6133569ef10911d5f8f9adb5152144c2093db707a7ee15e11bb81b51bd5dd679", size = 4863761, upload-time = "2025-06-16T12:28:14.018Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/fa/d16f27b1d839e1f0c562541685df420958a3ea9bd5e2bc74468bbb709162/skeliner-0.1.14.tar.gz", hash = "sha256:e9d803a327066be1d227c7b9b3bfbf14f9fa23201ddcc9abb8a081aaaa625b66", size = 11344674, upload-time = "2025-09-09T15:34:42.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/37/34ec4f503116ee0b70f010ca0b51b9eaf827a12dee99692d1bc1003dfaca/skeliner-0.1.6-py3-none-any.whl", hash = "sha256:c0cd70ec41ad7194aa7e24c6fa7b733fc5a1e9537ce19b2ad1d652d49563108e", size = 59838, upload-time = "2025-06-16T12:28:11.735Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c3/6d9ecf8caa835c9254354e0c9dc75765de1d4149a6c5479aa4ca8895c3bc/skeliner-0.1.14-py3-none-any.whl", hash = "sha256:49bf03d0ccc121cc25358ea3b556296cf64a70e3d60c66b81afaf788cc728f54", size = 92221, upload-time = "2025-09-09T15:34:41.2Z" },
 ]
 
 [[package]]
@@ -1833,14 +1792,14 @@ wheels = [
 
 [[package]]
 name = "trimesh"
-version = "4.6.11"
+version = "4.7.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/54/8b76552ad07a2f75fbeeee780e0407acf227c3fb8cf469676dd61adcbda8/trimesh-4.6.11.tar.gz", hash = "sha256:a10d92f2984f6ac9a5a53a6bd0ef0df309feed5c6b995c286edeea4abc553a68", size = 803050, upload-time = "2025-06-04T21:00:47.576Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/1c/6c5dcfd8e5defa1d1481450a7fccd429086c8fc4c57c3ea1a1ad0c2df432/trimesh-4.7.4.tar.gz", hash = "sha256:8d242dfabd9bc4e99a4f0c75bf8c0a41fbb252924e3484b53a8b0096accb49e1", size = 801995, upload-time = "2025-08-14T20:13:51.597Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/38/07997221694218e69df77a6100e997dd5b0298acfba3e030a4d0101ac148/trimesh-4.6.11-py3-none-any.whl", hash = "sha256:81e372cedcef1313e7d59661dd573de313bfe76ca3834188510579f52d91dc61", size = 711711, upload-time = "2025-06-04T21:00:44.996Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7d/37f1b50037c1448cacf875b305a3cdfddc113073d1cfbabe1a3b78939bae/trimesh-4.7.4-py3-none-any.whl", hash = "sha256:47af90235f7006316c37584b43d5f6c109a5069b252d7ab2bf8e6ed7c9fd953b", size = 709841, upload-time = "2025-08-14T20:13:48.964Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The original MATLAB implementation used `segment_lengths` as a measure of the xyz density. This RP added `volume` as a measure for both z and xy profile. 

Both length-based and volume-based profiles will be computed in `warp_skeleton()` automatically, which introduced a tiny **breaking change**:

The previous length-based profiles (`skel.extra["z_profile"]` and `skel.extra["xy_profile"]`) now becomes `skel.extra["z_profiles"]["length"]` and `skel.extra["xy_profiles"]["length"]` (`profile`-> `profiles`), and the volume-based profiles can be accessed via `skel.extra["z_profiles"]["volume"]` and `skel.extra["xy_profiles"]["volume"]`.